### PR TITLE
added Check Time debug step to both scheduled workflows - debugging time

### DIFF
--- a/.github/workflows/test-schedule.yml
+++ b/.github/workflows/test-schedule.yml
@@ -7,5 +7,7 @@ jobs:
   test_job:
     runs-on: ubuntu-latest
     steps:
+      - name: Check time          #  ← new (for debugging time)
+        run: date -u              #  ← new (prints current UTC)
       - name: Print Message
         run: echo "Test scheduled workflow triggered at $(date)"

--- a/.github/workflows/weekly-pages-deploy.yml
+++ b/.github/workflows/weekly-pages-deploy.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check time          #  ← new (for debugging time)
+        run: date -u              #  ← new (prints current UTC)
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
the run: date -u step will print the UTC timestamp at runtime, so we can confirm exactly when the scheduler is actually firing