### PR TITLE
Added staggered 5min test schedule

### DIFF
--- a/.github/workflows/staggoooorred-5-min-test.yml
+++ b/.github/workflows/staggoooorred-5-min-test.yml
@@ -1,5 +1,4 @@
-# .github/workflows/staggered-5-min-test.yml
-name: Test staggoooorred 5 min schedule
+name: Test Staggered Schedule
 
 on:
   # two staggered schedules

--- a/.github/workflows/staggoooorred-5-min-test.yml
+++ b/.github/workflows/staggoooorred-5-min-test.yml
@@ -1,0 +1,24 @@
+# .github/workflows/staggered-5-min-test.yml
+name: Test staggoooorred 5 min schedule
+
+on:
+  # two staggered schedules
+  schedule:
+    - cron: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *'
+    - cron: '3/5 * * * *'
+
+  # lets you fire it by hand while it’s still in a PR
+  workflow_dispatch:
+
+concurrency:
+  group: every-5-min
+  cancel-in-progress: true   # first copy wins, duplicates die  ↑ :contentReference[oaicite:0]{index=0}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: UTC timestamp
+        run: date -u
+      - name: Say hello
+        run: echo "staggoooooor-test fired at $(date -u)"


### PR DESCRIPTION
added a separate test workflow that:

- fires every 5 mins using two staggered `cron` entries: `2/5` and `3/5`
- avoids the top of hour minute in attempt to reduce queue delays
- uses `concurrency.cancel-in-progress: true` so only the first one executes per interval
- includes a `workflow_dispatch` block for manual testing before merging

should have no impact on production jobs, but safer to **test in PR** for evaluating runtime ... **merge only if satisfied**

goal: theoretically doubling the chances that github queues it on time -> therefore the job _actually_ runs every 5 mins
