### PR TITLE
responsive design (mobile) improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-checklist",
-  "version": "5.0",
+  "version": "5.0.1",
   "description": "A Warframe Task Checklist to track daily, weekly, and other tasks. Built with HTML, CSS, and vanilla JavaScript, processed with Vite.",
   "type": "module",
   "scripts": {

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -168,6 +168,13 @@ body.light-mode::before {
     border-radius: 0.5rem;
     box-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1),
                 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    @media (width < 48rem) {
+        padding: 1.5rem;
+        margin: 0 auto;
+    }
+    @media (width < 30rem) {
+        padding: 1rem;
+    }
 }
 #site-header {
     display: flex;
@@ -176,13 +183,16 @@ body.light-mode::before {
     align-items: center;
     margin-bottom: 1rem;
 }
-.checklist-content h1 {
+h1 {
     color: var(--text-header);
     font-size: 1.875rem;
-    line-height: 2.25rem;
+    line-height: 1.2em;
     font-weight: 700;
+    @media (width < 48rem) {
+        font-size: 1.75rem;
+    }
 }
-.checklist-content h2 {
+h2 {
     color: var(--text-header);
     cursor: pointer;
     display: flex;
@@ -196,16 +206,16 @@ body.light-mode::before {
     margin-bottom: 0.25rem;
     border-bottom: 1px solid var(--border-color);
 }
-.checklist-content h2 > span:first-of-type {
+h2 > span:first-of-type {
     flex-grow: 1;
 }
-.checklist-content h2 .reset-time-local {
+h2 .reset-time-local {
     font-size: 0.75rem;
     font-weight: 400;
     color: var(--text-secondary);
     margin-left: 0.5rem;
 }
-.checklist-content .app-description {
+.app-description {
     color: var(--text-secondary);
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
@@ -257,6 +267,7 @@ body.light-mode::before {
 #site-controls {
     display: flex;
     align-items: center;
+    margin-left: auto;
 }
 #site-header button {
     font-weight: 600;

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -24,10 +24,10 @@
 }
 
 /* --- Content Box Element Styling (Non-Critical Parts) --- */
-.checklist-content h2:hover {
+h2:hover {
     background-color: var(--section-header-hover-bg);
 }
-.checklist-content .task-description { color: var(--text-label); }
+.task-description { color: var(--text-label); }
 
 #save-info {
     margin-top: 1rem;
@@ -57,21 +57,21 @@ footer {
     text-align: center;
 }
 
-.checklist-content .footer-links {
+.footer-links {
     font-size: 0.75rem;
     color: var(--text-muted);
     margin-top: 2rem;
 }
-.checklist-content .footer-links a {
+.footer-links a {
     color: var(--link-color);
     text-decoration: underline;
     transition: color 0.2s ease;
     margin: 0 0.25rem;
 }
-.checklist-content .footer-links a:hover {
+.footer-links a:hover {
     color: var(--link-hover-color);
 }
-.checklist-content .footer-links span {
+.footer-links span {
     color: var(--text-muted);
     margin: 0 0.1rem;
 }
@@ -94,6 +94,7 @@ footer {
     list-style: none;
     margin-top: 0.5rem;
     padding: 0;
+    min-width: 0; /* be more aggressive about prventing text cutoff on very narrow screens */
 }
 
 a.git-hash-text {
@@ -505,7 +506,9 @@ body:not(.light-mode) img.icon-filter {
     content: "|";
     margin: 0 0.5em;
 }
-.info-line > span {
+.info-line > span > span {
+    /* keep the info line icon on the same line as the first word of the info line item.
+     * e.g.: {prereq_icon}[NO_BREAK]Mastery[BREAK_OK]Rank[BREAK_OK]3 */
     white-space: nowrap;
 }
 .task-info-expander svg {
@@ -518,4 +521,5 @@ body:not(.light-mode) img.icon-filter {
 }
 .tooltip {
     text-decoration: underline dotted;
+    cursor: pointer;
 }

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -31,7 +31,7 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.0";
+const APP_VERSION = "5.0.1";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
 const WARFRAME_VERSION = "42.0.11";


### PR DESCRIPTION
# responsive design (mobile) improvements

* fixes #49:
  * allow info line items to word-wrap (except between icon and first word of text).
  * specify a min-width for task lists, so they can shrink further instead of overflowing the padding.
* shrink padding on narrow screens to squeeze in a little more content
* remove checklist-content margin when it's smaller than the max-width so that the background doesn't peek over the top (since it's already not visible on the sides)
* site-controls always stay on the right side, even when they line wrap

## Plus:
* tooltip for unavailable task's countdown no longer has not-allowed cursor
* removed a bunch of superfluous ".checklist-content" from CSS rules. (The extra specificity was needed to override Tailwind's default styles, but sanitize.css uses zero-specificity `:where()` rules)
* bump version to 5.0.1