### PR TITLE
Internationalization (i18n) – multi-language support, 15 locales, smart detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-checklist",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "A Warframe Task Checklist to track daily, weekly, and other tasks. Built with HTML, CSS, and vanilla JavaScript, processed with Vite.",
   "type": "module",
   "scripts": {

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -180,8 +180,16 @@ body.light-mode::before {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 0.5rem 1rem;
     margin-bottom: 1rem;
+}
+/* take the remaining width and let the description wrap onto a new line, so the
+   controls stay on the title's line instead of dropping below (e.g. longer
+   translations like French) */
+#site-header hgroup {
+    flex: 1 1 0;
+    min-width: 0;
 }
 h1 {
     color: var(--text-header);
@@ -268,6 +276,7 @@ h2 .reset-time-local {
     display: flex;
     align-items: center;
     margin-left: auto;
+    flex-shrink: 0; /* keep the controls intact on the title's line; never wrap below */
 }
 #site-header button {
     font-weight: 600;
@@ -282,6 +291,93 @@ h2 .reset-time-local {
 }
 #site-header button:not(:last-of-type) { margin-right: 0.5rem; }
 #site-header button:not(:first-of-type) { margin-left: 0.5rem; }
+/* language switcher: custom dropdown (native <select> popups can't be themed) */
+#language-switcher {
+    position: relative;
+    margin-right: 0.5rem;
+}
+.lang-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    letter-spacing: 0.04em;
+    padding: 0.375rem 0.5rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--theme-toggle-border);
+    background-color: transparent;
+    color: var(--theme-toggle-color);
+    cursor: pointer;
+    line-height: 1.5;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+.lang-trigger:hover {
+    background-color: var(--theme-toggle-hover-bg);
+    border-color: var(--theme-toggle-hover-border);
+}
+.lang-trigger:focus-visible {
+    outline: 2px solid var(--theme-toggle-hover-border);
+    outline-offset: 2px;
+}
+.lang-trigger .lang-chevron { width: 0.8rem; height: 0.8rem; flex-shrink: 0; transition: transform 0.2s ease; }
+#language-switcher.open .lang-chevron { transform: rotate(180deg); }
+.lang-current { font-variant-numeric: tabular-nums; }
+
+.lang-menu {
+    position: absolute;
+    top: calc(100% + 0.4rem);
+    right: 0;
+    min-width: 11rem;
+    margin: 0;
+    padding: 0.3rem;
+    list-style: none;
+    background-color: var(--menu-panel-bg);
+    border: 1px solid var(--menu-panel-border);
+    border-radius: 0.5rem;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    z-index: 60;
+}
+.lang-option {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    color: var(--text-primary);
+    transition: background-color 0.15s ease;
+}
+.lang-option:hover,
+.lang-option:focus-visible {
+    background-color: var(--section-header-hover-bg);
+    outline: none;
+}
+.lang-option-code {
+    min-width: 1.75rem;
+    font-weight: 600;
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+}
+.lang-option-name { flex: 1; font-size: 0.875rem; }
+.lang-option.is-selected,
+.lang-option.is-selected .lang-option-code { color: var(--text-header); }
+.lang-check { width: 1rem; height: 1rem; flex-shrink: 0; color: var(--text-header); }
+
+/* "help translate" footer link, separated from the language list */
+.lang-help {
+    margin-top: 0.3rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid var(--menu-panel-border);
+    color: var(--text-secondary);
+}
+.lang-help .lang-option-name { font-size: 0.8rem; }
+.lang-ext { width: 0.8rem; height: 0.8rem; flex-shrink: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+    .lang-trigger .lang-chevron { transition: none; }
+}
 #site-header button svg {
     width: 1.25rem;
     height: 1.25rem;

--- a/sources/index.html
+++ b/sources/index.html
@@ -1,8 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" translate="no">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- The app localizes itself; stop browser auto-translators from mutating the DOM and fighting our live updates -->
+    <meta name="google" content="notranslate">
+    <meta name="translate" content="no">
     <title>Warframe Task Checklist</title>
     <link rel="icon" href="img/favicon.ico" type="image/x-icon">
     <style type="text/css">
@@ -45,17 +48,18 @@
 
     <div class="checklist-content">
         <div id="error-display"> <span id="error-message"></span>
-            <button id="error-copy-button">Copy</button>
-            <button id="error-close-button" aria-label="Close error message">&times;</button>
+            <button id="error-copy-button" data-i18n="error.copy">Copy</button>
+            <button id="error-close-button" data-i18n-aria-label="aria.closeError" aria-label="Close error message">&times;</button>
         </div>
 
         <header id="site-header">
             <hgroup>
-                <h1>Warframe Task Checklist</h1>
-                <p class="app-description">Track your daily, weekly, and other Warframe tasks.</p>
+                <h1 data-i18n="app.title">Warframe Task Checklist</h1>
+                <p class="app-description" data-i18n="app.description">Track your daily, weekly, and other Warframe tasks.</p>
             </hgroup>
             <div id="site-controls">
-                <button id="theme-toggle-button" aria-label="Toggle theme">
+                <div id="language-switcher"></div>
+                <button id="theme-toggle-button" data-i18n-aria-label="aria.toggleTheme" aria-label="Toggle theme">
                     <svg id="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5h2.25a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.166 7.758a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/>
                     </svg>
@@ -63,7 +67,7 @@
                         <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.7-10.5-10.5 0-3.51 1.713-6.637 4.43-8.565a.75.75 0 01.981.162z" clip-rule="evenodd"/>
                     </svg>
                 </button>
-                <button id="hamburger-button" aria-label="Open menu">
+                <button id="hamburger-button" data-i18n-aria-label="aria.openMenu" aria-label="Open menu">
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
                     </svg>
@@ -74,8 +78,8 @@
         <div id="checklist-container">
             <section id="daily-tasks-section">
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="daily-tasks-content">
-                    <span>Daily Tasks <span class="reset-time-local" id="daily-reset-local-time">(Resets ...)</span></span>
-                    <button class="hide-section-button" data-section-id="daily-tasks-section">Hide Section</button>
+                    <span><span data-i18n="section.daily">Daily Tasks</span> <span class="reset-time-local" id="daily-reset-local-time" data-i18n="countdown.resetEllipsis">(Resets ...)</span></span>
+                    <button class="hide-section-button" data-section-id="daily-tasks-section" data-i18n="section.hide">Hide Section</button>
                     <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
@@ -87,8 +91,8 @@
 
             <section id="weekly-tasks-section">
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="weekly-tasks-content">
-                    <span>Weekly Tasks <span class="reset-time-local" id="weekly-reset-local-time">(Resets ...)</span></span>
-                    <button class="hide-section-button" data-section-id="weekly-tasks-section">Hide Section</button>
+                    <span><span data-i18n="section.weekly">Weekly Tasks</span> <span class="reset-time-local" id="weekly-reset-local-time" data-i18n="countdown.resetEllipsis">(Resets ...)</span></span>
+                    <button class="hide-section-button" data-section-id="weekly-tasks-section" data-i18n="section.hide">Hide Section</button>
                     <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
@@ -100,8 +104,8 @@
 
             <section id="other-tasks-section">
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="other-tasks-content">
-                    <span>Other Tasks</span>
-                    <button class="hide-section-button" data-section-id="other-tasks-section">Hide Section</button>
+                    <span><span data-i18n="section.other">Other Tasks</span></span>
+                    <button class="hide-section-button" data-section-id="other-tasks-section" data-i18n="section.hide">Hide Section</button>
                     <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
@@ -113,12 +117,12 @@
         </div>
 
         <div id="save-info">
-            <p id="save-status">Saved!</p>
-            <p id="last-saved-timestamp">Loading...</p>
-            <p id="storage-notice">Your progress is saved locally.</p>
+            <p id="save-status" data-i18n="save.saved">Saved!</p>
+            <p id="last-saved-timestamp" data-i18n="save.loading">Loading...</p>
+            <p id="storage-notice" data-i18n="save.storageNotice">Your progress is saved locally.</p>
         </div>
 
-        <p class="reminder-notice">*Remember, you don't have to do everything! Prioritize tasks based on your current goals and progress.*</p>
+        <p class="reminder-notice" data-i18n="reminder">*Remember, you don't have to do everything! Prioritize tasks based on your current goals and progress.*</p>
 
         <footer>
             <div class="footer-links">
@@ -126,7 +130,7 @@
                 <span>|</span>
                 <a href="https://github.com/warframe-tools/Task-Checklist" target="_blank" rel="noopener noreferrer">Github</a>
                 <span>|</span>
-                <a href="https://github.com/warframe-tools/Task-Checklist?tab=GPL-3.0-1-ov-file" target="_blank" rel="noopener noreferrer">License (GPLv3)</a>
+                <a href="https://github.com/warframe-tools/Task-Checklist?tab=GPL-3.0-1-ov-file" target="_blank" rel="noopener noreferrer" data-i18n="footer.license">License (GPLv3)</a>
                 <span>|</span>
                 <a href="https://hub.warframestat.us/" target="_blank" rel="noopener noreferrer">Warframe Hub</a>
                 <span>|</span>
@@ -136,9 +140,9 @@
             </div>
 
             <div id="footer-info">
-                <p>App Version <span class="version-text">X</span> (<a class="git-hash-text" target="_blank" rel="noopener noreferrer">X</a>)</p>
+                <p><span data-i18n="footer.appVersion">App Version</span> <span class="version-text">X</span> (<a class="git-hash-text" target="_blank" rel="noopener noreferrer">X</a>)</p>
                 <p class="warframe-version-text">Warframe Version X</p>
-                <p class="disclaimer-text">
+                <p class="disclaimer-text" data-i18n="footer.disclaimer">
                     This is an unofficial fan-made tool. Warframe and all related assets are the intellectual property of Digital Extremes Ltd. This project is not affiliated with, endorsed by, or sponsored by Digital Extremes Ltd.
                 </p>
             </div>
@@ -148,21 +152,21 @@
     <dialog id="options-menu">
         <div id="menu-content-box">
             <header class="menu-header">
-                <h2 class="menu-title">Options</h2>
-                <button class="menu-close-button" aria-label="Close menu">&times;</button>
+                <h2 class="menu-title" data-i18n="menu.options">Options</h2>
+                <button class="menu-close-button" data-i18n-aria-label="aria.closeMenu" aria-label="Close menu">&times;</button>
             </header>
-            <button id="reset-daily-button" class="menu-btn">Reset Daily Checks</button>
-            <button id="reset-weekly-button" class="menu-btn">Reset Weekly Checks</button>
-            <button id="reset-button" class="menu-btn">Reset All Checks</button>
-            <button id="unhide-tasks-button" class="menu-btn">Unhide All Tasks</button>
+            <button id="reset-daily-button" class="menu-btn" data-i18n="menu.resetDaily">Reset Daily Checks</button>
+            <button id="reset-weekly-button" class="menu-btn" data-i18n="menu.resetWeekly">Reset Weekly Checks</button>
+            <button id="reset-button" class="menu-btn" data-i18n="menu.resetAll">Reset All Checks</button>
+            <button id="unhide-tasks-button" class="menu-btn" data-i18n="menu.unhideAll">Unhide All Tasks</button>
         </div>
     </dialog>
 
     <dialog id="cycle-schedule">
         <div>
             <header class="menu-header">
-                <h2 class="menu-title"><img class="task-icon" />Schedule for <span class="title">X</span></h2>
-                <button class="menu-close-button" aria-label="Close schedule">&times;</button>
+                <h2 class="menu-title"><img class="task-icon" /><span data-i18n="schedule.for">Schedule for</span> <span class="title">X</span></h2>
+                <button class="menu-close-button" data-i18n-aria-label="aria.closeSchedule" aria-label="Close schedule">&times;</button>
             </header>
             <table>
                 <thead></thead>
@@ -175,7 +179,7 @@
         <div>
             <header class="menu-header">
                 <h2 class="menu-title"><img class="task-icon" /><span class="title">X</span></h2>
-                <button class="menu-close-button" aria-label="Close schedule">&times;</button>
+                <button class="menu-close-button" data-i18n-aria-label="aria.closeSchedule" aria-label="Close schedule">&times;</button>
             </header>
             <div id="more-info-content"></div>
         </div>

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -21,6 +21,9 @@ import * as C from "./constants.js";
 
 import * as svgIcons from "./icons.js";
 
+import * as i18n from "./i18n/i18n.js";
+import { t } from "./i18n/i18n.js";
+
 // --- Configuration ---
 // Array of background div IDs (must match IDs in sources/index.html)
 const dailyBackgroundImageIds = [
@@ -31,7 +34,7 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.0.1";
+const APP_VERSION = "5.1.0";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
 const WARFRAME_VERSION = "42.0.11";
@@ -47,13 +50,17 @@ import cycles from "./cycles.json" with {type: "json"};
 import moreInfo from "./moreInfo.js";
 
 function _prepTasks() {
+    // overlay translations onto the task/cycle data first so everything downstream sees localized text
+    i18n.localizeTasks(tasks);
+    i18n.localizeCycles(cycles);
+
     function prep(period) {
         return (task) => {
             if (task.ref) { // alternate ref tasks need a period for countdown and reset to work correctly
                 task.period = period;
             }
             if (task.id in moreInfo) {
-                task.moreInfo = moreInfo[task.id];
+                task.moreInfo = i18n.getMoreInfo(task.id) ?? moreInfo[task.id];
             }
         }
     }
@@ -66,7 +73,7 @@ _prepTasks();
 let bodyElement, themeToggleButton, hamburgerButton, optionsMenu, resetDailyButton, resetWeeklyButton, resetButton,
     unhideTasksButton, lastSavedTimestampElement, saveStatusElement, sectionToggles, dailyResetTimeElement,
     weeklyResetTimeElement, errorDisplayElement, errorMessageElement, errorCloseButton, errorCopyButton,
-    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, backgroundDivs = [];
+    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, languageSwitcherElement, backgroundDivs = [];
 
 
 // --- State Variables ---
@@ -118,6 +125,7 @@ function initializeDOMElements() {
     wfVersionElement = document.querySelector('.warframe-version-text');
     scheduleDialog = document.getElementById("cycle-schedule");
     moreInfoDialog = document.getElementById("more-info");
+    languageSwitcherElement = document.getElementById("language-switcher");
 
     backgroundDivs = [];
     dailyBackgroundImageIds.forEach((id) => {
@@ -135,37 +143,37 @@ function displayError(message) {
     console.error("Displaying Error:", message);
     errorMessageElement.textContent = message;
     errorDisplayElement.classList.add("visible");
-    if (errorCopyButton) { errorCopyButton.textContent = "Copy"; }
+    if (errorCopyButton) { errorCopyButton.textContent = t("error.copy"); }
 }
 
 function hideError() {
     if (!errorDisplayElement) { return; }
     errorDisplayElement.classList.remove("visible");
     errorMessageElement.textContent = '';
-    if (errorCopyButton) { errorCopyButton.textContent = "Copy"; }
+    if (errorCopyButton) { errorCopyButton.textContent = t("error.copy"); }
 }
 
 function copyErrorToClipboard() {
     const errorMessage = errorMessageElement.textContent;
     if (!errorMessage || !navigator.clipboard) {
         console.warn("Clipboard API not available or no error message to copy.");
-        if (errorCopyButton) { errorCopyButton.textContent = "Failed"; }
+        if (errorCopyButton) { errorCopyButton.textContent = t("error.failed"); }
         setTimeout(() => {
-            if (errorCopyButton) { errorCopyButton.textContent = "Copy"; }
+            if (errorCopyButton) { errorCopyButton.textContent = t("error.copy"); }
         }, 2000);
         return;
     }
     navigator.clipboard.writeText(errorMessage).then(() => {
         console.log("Error message copied to clipboard.");
-        if (errorCopyButton) { errorCopyButton.textContent = "Copied!"; }
+        if (errorCopyButton) { errorCopyButton.textContent = t("error.copied"); }
         setTimeout(() => {
-            if (errorCopyButton) { errorCopyButton.textContent = "Copy"; }
+            if (errorCopyButton) { errorCopyButton.textContent = t("error.copy"); }
         }, 2000);
     }).catch((err) => {
         console.error("Failed to copy error message: ", err);
-        if (errorCopyButton) { errorCopyButton.textContent = "Failed"; }
+        if (errorCopyButton) { errorCopyButton.textContent = t("error.failed"); }
         setTimeout(() => {
-            if (errorCopyButton) { errorCopyButton.textContent = "Copy"; }
+            if (errorCopyButton) { errorCopyButton.textContent = t("error.copy"); }
         }, 2000);
     });
 }
@@ -188,7 +196,7 @@ function handleThemeToggle() {
         localStorage.setItem(THEME_STORAGE_KEY, newTheme);
     } catch (e) {
         console.error("Could not save theme preference:", e);
-        displayError("Could not save theme preference.");
+        displayError(t("errors.themeSaveFailed"));
     }
 }
 
@@ -215,7 +223,8 @@ function loadThemePreference() {
 
 function updateLastSavedDisplay(timestamp) {
     if (lastSavedTimestampElement) {
-        lastSavedTimestampElement.textContent = `Last saved: ${formatTimestamp(timestamp)}`;
+        const time = timestamp ? formatTimestamp(timestamp) : t("save.never");
+        lastSavedTimestampElement.textContent = t("save.lastSaved", { time });
     } else {
         console.error("lastSavedTimestampElement not found");
     }
@@ -264,7 +273,8 @@ function displayLocalResetTimes() {
         const nextDailyResetTimestamp = getNextDailyMidnightUTC();
         const dailyDiff = nextDailyResetTimestamp - now;
         if (dailyResetTimeElement) {
-            dailyResetTimeElement.innerHTML = `(Resets in <span class="tooltip" title="${new Date(nextDailyResetTimestamp).toString()}">${formatCountdown(dailyDiff)}</span>)`;
+            const timer = `<span class="tooltip" title="${new Date(nextDailyResetTimestamp).toString()}">${formatCountdown(dailyDiff)}</span>`;
+            dailyResetTimeElement.innerHTML = t("countdown.resetsInTimer", { timer });
         }
 
         // Weekly
@@ -274,7 +284,8 @@ function displayLocalResetTimes() {
         }
         const weeklyDiff = nextWeeklyResetTimestamp - now;
         if (weeklyResetTimeElement) {
-            weeklyResetTimeElement.innerHTML = `(Resets in <span class="tooltip" title="${new Date(nextWeeklyResetTimestamp).toString()}">${formatCountdown(weeklyDiff)}</span>)`;
+            const timer = `<span class="tooltip" title="${new Date(nextWeeklyResetTimestamp).toString()}">${formatCountdown(weeklyDiff)}</span>`;
+            weeklyResetTimeElement.innerHTML = t("countdown.resetsInTimer", { timer });
         }
 
         // Other
@@ -283,8 +294,8 @@ function displayLocalResetTimes() {
         tasks.other.forEach((task) => displayOtherTaskCountdown(task));
     } catch (e) {
         console.error("Error calculating or displaying local reset times:", e);
-        if (dailyResetTimeElement) { dailyResetTimeElement.innerHTML = `(Resets 00:00 UTC)`; }
-        if (weeklyResetTimeElement) { weeklyResetTimeElement.innerHTML = `(Resets Mon 00:00 UTC)`; }
+        if (dailyResetTimeElement) { dailyResetTimeElement.textContent = t("countdown.dailyFallback"); }
+        if (weeklyResetTimeElement) { weeklyResetTimeElement.textContent = t("countdown.weeklyFallback"); }
     }
 }
 
@@ -300,20 +311,24 @@ export function displayOtherTaskCountdown(task) {
 
         if (taskTimes.isAvailable) {
             const diff = taskTimes.thisCycleLeaveTimestamp - now.getTime();
-            resetTimer.innerHTML = `(Available for <span class="tooltip" title="${new Date(taskTimes.thisCycleLeaveTimestamp).toString()}">${formatCountdown(diff)}</span>)`;
+            const timer = `<span class="tooltip" title="${new Date(taskTimes.thisCycleLeaveTimestamp).toString()}">${formatCountdown(diff)}</span>`;
+            resetTimer.innerHTML = t("countdown.availableForTimer", { timer });
 
             // Leaving soon notification (Arrival notification is handled in runAutoResets, the same as always available tasks)
             if (diff < C.MILLISECONDS_PER_HOUR && checklistData.notificationPreferences[task.id] && checklistData.notificationsSent[leaveNotifId] !== cycleNumber) {
-                showNotification(`${task.text.split(":")[0]} Leaving Soon!`, `Approximately ${Math.round(diff / C.MILLISECONDS_PER_MINUTE)} minutes remaining.`);
+                const name = task.text.split(":")[0];
+                showNotification(t("notif.leavingSoonTitle", { name }), t("notif.leavingSoonBody", { minutes: Math.round(diff / C.MILLISECONDS_PER_MINUTE) }));
                 checklistData.notificationsSent[leaveNotifId] = cycleNumber;
                 saveData(false);
             }
         } else { // task not available
-            resetTimer.innerHTML = `(Available in <span class="tooltip" title="${new Date(taskTimes.nextResetTimestamp).toString()}">${formatCountdown(taskTimes.nextResetTimestamp - now.getTime())}</span>)`;
+            const timer = `<span class="tooltip" title="${new Date(taskTimes.nextResetTimestamp).toString()}">${formatCountdown(taskTimes.nextResetTimestamp - now.getTime())}</span>`;
+            resetTimer.innerHTML = t("countdown.availableInTimer", { timer });
             if (checklistData.notificationsSent[leaveNotifId]) {delete checklistData.notificationsSent[leaveNotifId];}
         }
     } else { // always available task
-        resetTimer.innerHTML = `(Resets in <span class="tooltip" title="${new Date(taskTimes.nextResetTimestamp).toString()}">${formatCountdown(taskTimes.nextResetTimestamp - now.getTime())}</span>)`;
+        const timer = `<span class="tooltip" title="${new Date(taskTimes.nextResetTimestamp).toString()}">${formatCountdown(taskTimes.nextResetTimestamp - now.getTime())}</span>`;
+        resetTimer.innerHTML = t("countdown.resetsInTimer", { timer });
     }
 }
 
@@ -385,7 +400,7 @@ function otherTaskReset(task) {
 
         // Send and record new notification
         if (checklistData.notificationPreferences[task.id] && checklistData.notificationsSent[task.id] !== cycleNumber) {
-            showNotification(`${task.text.split(":")[0]} has reset!`, "Vendor stock may have updated.");
+            showNotification(t("notif.resetTitle", { name: task.text.split(":")[0] }), t("notif.resetBody"));
             checklistData.notificationsSent[task.id] = cycleNumber;
             saveData(false);
         }
@@ -397,7 +412,7 @@ function otherTaskReset(task) {
 async function requestNotificationPermission() {
     if (!("Notification" in window)) {
         console.warn("This browser does not support desktop notification");
-        alert("This browser does not support desktop notifications.");
+        alert(t("notif.noSupport"));
         return false;
     }
     if (Notification.permission === "granted") {
@@ -408,11 +423,11 @@ async function requestNotificationPermission() {
         if (permission === "granted") {
             return true;
         } else {
-            alert("Notification permission was denied. You can enable it in your browser settings.");
+            alert(t("notif.denied"));
             return false;
         }
     } else {
-        alert("Notification permission has been denied. Please enable it in your browser settings if you wish to receive notifications.");
+        alert(t("notif.deniedPersist"));
         return false;
     }
 }
@@ -469,8 +484,9 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     if (task.id.startsWith('other_')) {
         const notificationButton = document.createElement('button');
         notificationButton.classList.add('notification-toggle-btn');
-        notificationButton.setAttribute('aria-label', `Toggle notifications for ${task.text.split(':')[0]}`);
-        notificationButton.title = `Toggle notifications for ${task.text.split(':')[0]}`;
+        const notifLabel = t("notif.toggleFor", { name: task.text.split(':')[0] });
+        notificationButton.setAttribute('aria-label', notifLabel);
+        notificationButton.title = notifLabel;
 
         notificationButton.innerHTML = svgIcons.bellIcon;
         if (checklistData.notificationPreferences[task.id]) { notificationButton.classList.add("active"); }
@@ -491,8 +507,9 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     // Hide Button
     const hideButton = document.createElement('button');
     hideButton.classList.add('hide-task-btn');
-    hideButton.setAttribute('aria-label', `Hide task: ${task.text.split(':')[0]}`);
-    hideButton.title = `Hide task: ${task.text.split(':')[0]}`;
+    const hideLabel = t("notif.hideTask", { name: task.text.split(':')[0] });
+    hideButton.setAttribute('aria-label', hideLabel);
+    hideButton.title = hideLabel;
     hideButton.innerHTML = svgIcons.hideIcon;
     hideButton.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -606,7 +623,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         if (task.period) {
             const resetTimer = document.createElement("span");
             resetTimer.classList.add("other-countdown");
-            resetTimer.textContent = "(Loading...)";
+            resetTimer.textContent = t("countdown.loading");
             label.appendChild(resetTimer);
         }
 
@@ -681,7 +698,7 @@ function showScheduleAction(task, period, cycleIndex, isAvailable) {
         thead.innerHTML = "";
         tbody.innerHTML = "";
 
-        let header = `<tr><th>Date</th>`;
+        let header = `<tr><th>${t("schedule.date")}</th>`;
         for (const column of cycles[task.id].columns) {
             header += `<th>${column.name}</th>`;
         }
@@ -694,7 +711,7 @@ function showScheduleAction(task, period, cycleIndex, isAvailable) {
         const currentCycleStartTime = ref.getTime() + (period * cyclesSinceRef);
 
         for (let i = 0; i <= cycleCount; i++) {
-            let date = "Now";
+            let date = t("schedule.now");
             if (i !== 0 || !isAvailable) {
                 const rowCycleStartDate = new Date(currentCycleStartTime + (period * i));
                 date = rowCycleStartDate.toISOString().split("T")[0]; // toISOString is always in UTC, which is what we want. The part before "T" is the date
@@ -702,7 +719,7 @@ function showScheduleAction(task, period, cycleIndex, isAvailable) {
 
             let repeat = "";
             if (i === cycleCount) {
-                repeat = `<tr><td colspan="${cycles[task.id].columns.length + 1}" class="cycle-repeats">(Cycle Repeats)</td></tr>`;
+                repeat = `<tr><td colspan="${cycles[task.id].columns.length + 1}" class="cycle-repeats">${t("schedule.cycleRepeats")}</td></tr>`;
             }
 
             let row = `${repeat}<tr><td>${date}</td>`; // intermediate `row` variable is needed because manipulating `tbody.innerHTML` automatically adds `</tr>` tag
@@ -751,19 +768,19 @@ function makeInfoLine(task, appendTo) {
             let prefix, period, cycleIndex;
             const isAvailable = calcTaskTimes(task, now).isAvailable;
             if (task.id.startsWith("weekly_")) {
-                prefix = "This&nbsp;Week";
+                prefix = t("cycle.thisWeek");
                 period = 7 * C.MILLISECONDS_PER_DAY;
                 if (ref.getUTCDay() !== 1) {
                     console.warn(`${task.id} cycle ref ${cycles[task.id].ref} is not a Monday`);
                 }
             }
             else if (task.id.startsWith("daily_")) {
-                prefix = "Today";
+                prefix = t("cycle.today");
                 period = C.MILLISECONDS_PER_DAY;
             }
             else {
-                prefix = "Current&nbsp;Cycle";
-                if (!isAvailable) {prefix = "Next&nbsp;Cycle";}
+                prefix = t("cycle.currentCycle");
+                if (!isAvailable) {prefix = t("cycle.nextCycle");}
                 period = parseDuration(task.period);
             }
 
@@ -785,7 +802,7 @@ function makeInfoLine(task, appendTo) {
             const showSchedule = document.createElement("button");
             showSchedule.type = "button";
             showSchedule.classList.add("more-info-btn");
-            showSchedule.innerHTML = "Show&nbsp;Schedule";
+            showSchedule.innerHTML = t("info.showSchedule");
             showSchedule.addEventListener("click", showScheduleAction(task, period, cycleIndex, isAvailable));
             currentCycle.appendChild(showSchedule);
 
@@ -798,19 +815,19 @@ function makeInfoLine(task, appendTo) {
             const infoLine = document.createElement('div');
             infoLine.classList.add('info-line');
             let infoLineHTML = "";
-            infoLineHTML += makeInfoLineItem(task, "location", "Location", svgIcons.locationIcon);
-            infoLineHTML = infoLineHTML.replace('Base of Operations', C.BASE_OF_OPERATIONS_TOOLTIP);
-            infoLineHTML += makeInfoLineItem(task, "npc", "NPC", svgIcons.npcIcon);
-            infoLineHTML += makeInfoLineItem(task, "terminal", "Terminal", svgIcons.terminalIcon);
-            infoLineHTML += makeInfoLineItem(task, "prereq", "Requirements", svgIcons.prereqIcon);
-            infoLineHTML += makeInfoLineItem(task, "info", "Info", svgIcons.infoIcon);
+            infoLineHTML += makeInfoLineItem(task, "location", t("info.location"), svgIcons.locationIcon);
+            infoLineHTML = infoLineHTML.replace(t("baseOfOperations.label"), i18n.baseOfOperationsHTML());
+            infoLineHTML += makeInfoLineItem(task, "npc", t("info.npc"), svgIcons.npcIcon);
+            infoLineHTML += makeInfoLineItem(task, "terminal", t("info.terminal"), svgIcons.terminalIcon);
+            infoLineHTML += makeInfoLineItem(task, "prereq", t("info.requirements"), svgIcons.prereqIcon);
+            infoLineHTML += makeInfoLineItem(task, "info", t("info.info"), svgIcons.infoIcon);
             infoLine.innerHTML = infoLineHTML;
 
             if (task.moreInfo) {
                 const showMoreInfo = document.createElement("button");
                 showMoreInfo.type = "button";
                 showMoreInfo.classList.add("more-info-btn");
-                showMoreInfo.innerHTML = "More&nbsp;Info";
+                showMoreInfo.innerHTML = t("info.moreInfo");
                 showMoreInfo.addEventListener("click", showMoreInfoAction(task));
                 const span = document.createElement("span");
                 span.appendChild(showMoreInfo);
@@ -893,10 +910,10 @@ function handleResetConfirmation(buttonElement, confirmKey, defaultText, resetAc
         Object.keys(confirmState).forEach((key) => {
             if (key !== confirmKey && confirmState[key].isConfirming) {
                 let btnElement, btnText;
-                if (key === 'all') { btnElement = resetButton; btnText = 'Reset All Checks'; }
-                else if (key === 'daily') { btnElement = resetDailyButton; btnText = 'Reset Daily Checks'; }
-                else if (key === 'weekly') { btnElement = resetWeeklyButton; btnText = 'Reset Weekly Checks'; }
-                else if (key === 'unhide') { btnElement = unhideTasksButton; btnText = 'Unhide All Tasks'; }
+                if (key === 'all') { btnElement = resetButton; btnText = t("menu.resetAll"); }
+                else if (key === 'daily') { btnElement = resetDailyButton; btnText = t("menu.resetDaily"); }
+                else if (key === 'weekly') { btnElement = resetWeeklyButton; btnText = t("menu.resetWeekly"); }
+                else if (key === 'unhide') { btnElement = unhideTasksButton; btnText = t("menu.unhideAll"); }
                 if (btnElement) {
                     resetSpecificButtonState(btnElement, btnText, key);
                 }
@@ -910,7 +927,7 @@ function handleResetConfirmation(buttonElement, confirmKey, defaultText, resetAc
         resetSpecificButtonState(buttonElement, defaultText, confirmKey);
     } else {
         confirmState[confirmKey].isConfirming = true;
-        buttonElement.textContent = 'Are you Sure?';
+        buttonElement.textContent = t("menu.confirm");
         buttonElement.classList.add('confirming');
         clearTimeout(confirmState[confirmKey].timeout);
 
@@ -1056,9 +1073,9 @@ function saveData(showStatus = true) {
         if (showStatus) { showSaveStatus(); }
     } catch (e) {
         console.error("Error saving data to localStorage:", e);
-        let userMessage = "Could not save progress.";
+        let userMessage = t("errors.saveFailed");
         if (e.name === 'QuotaExceededError' || (e.code && (e.code === 22 || e.code === 1014))) {
-            userMessage = "Could not save progress. Browser storage might be full.";
+            userMessage = t("errors.saveFailedQuota");
         }
         displayError(userMessage);
     }
@@ -1082,7 +1099,7 @@ function loadData() {
             } else { console.warn("Invalid data format found in localStorage. Starting fresh."); }
         } catch (e) {
             console.error("Error parsing saved data:", e);
-            displayError("Failed to load saved progress. Data might be corrupted.");
+            displayError(t("errors.loadFailed"));
             checklistData = { progress: {}, lastSaved: null, lastDailyReset: null, lastWeeklyReset: null, hiddenTasks: {}, manuallyHiddenSections: {}, lastTaskResetTimes: {}, notificationPreferences: {}, notificationsSent: {} };
         }
     }
@@ -1090,6 +1107,8 @@ function loadData() {
 
 export function loadAndInitializeApp() {
     initializeDOMElements();
+    i18n.applyStaticTranslations();
+    i18n.setupLanguageSwitcher(languageSwitcherElement);
     hideError();
     loadThemePreference();
     loadData();
@@ -1109,19 +1128,19 @@ export function loadAndInitializeApp() {
         gitHashElement.href = `https://github.com/warframe-tools/Task-Checklist/tree/${GIT_COMMIT_HASH_LONG}`;
     } else { console.error("git hash element not found!"); }
 
-    if (wfVersionElement) { wfVersionElement.textContent = `Warframe Version ${WARFRAME_VERSION}`; }
+    if (wfVersionElement) { wfVersionElement.textContent = t("footer.warframeVersion", { version: WARFRAME_VERSION }); }
     else { console.error("Warframe version element not found!"); }
 
-    if (resetDailyButton) { resetDailyButton.addEventListener('click', () => handleResetConfirmation(resetDailyButton, 'daily', 'Reset Daily Checks', resetDailyAction)); }
+    if (resetDailyButton) { resetDailyButton.addEventListener('click', () => handleResetConfirmation(resetDailyButton, 'daily', t("menu.resetDaily"), resetDailyAction)); }
     else { console.error("Reset Daily button element not found!"); }
 
-    if (resetWeeklyButton) { resetWeeklyButton.addEventListener('click', () => handleResetConfirmation(resetWeeklyButton, 'weekly', 'Reset Weekly Checks', resetWeeklyAction)); }
+    if (resetWeeklyButton) { resetWeeklyButton.addEventListener('click', () => handleResetConfirmation(resetWeeklyButton, 'weekly', t("menu.resetWeekly"), resetWeeklyAction)); }
     else { console.error("Reset Weekly button element not found!"); }
 
-    if (resetButton) { resetButton.addEventListener('click', () => handleResetConfirmation(resetButton, 'all', 'Reset All Checks', resetAllAction)); }
+    if (resetButton) { resetButton.addEventListener('click', () => handleResetConfirmation(resetButton, 'all', t("menu.resetAll"), resetAllAction)); }
     else { console.error("Reset All button element not found!"); }
 
-    if (unhideTasksButton) { unhideTasksButton.addEventListener('click', () => handleResetConfirmation(unhideTasksButton, 'unhide', 'Unhide All Tasks', unhideAllAction)); }
+    if (unhideTasksButton) { unhideTasksButton.addEventListener('click', () => handleResetConfirmation(unhideTasksButton, 'unhide', t("menu.unhideAll"), unhideAllAction)); }
     else { console.error("Unhide Tasks button not found!");}
 
 
@@ -1193,11 +1212,12 @@ document.addEventListener("DOMContentLoaded", () => {
         console.error("Critical Error during app.js initialization:", error);
         const errDisp = document.getElementById("error-display");
         const errMsg = document.getElementById("error-message");
+        const criticalMessage = t("errors.critical");
         if (errDisp && errMsg) {
-            errMsg.textContent = "A critical error occurred during application startup. Please check the console.";
+            errMsg.textContent = criticalMessage;
             errDisp.classList.add("visible");
         } else {
-            alert("A critical error occurred during application startup. Please check the console.");
+            alert(criticalMessage);
         }
     }
 });

--- a/sources/js/functions.js
+++ b/sources/js/functions.js
@@ -126,7 +126,9 @@ export function isDst(date, timezone) {
         // returns the whole hour part of the UTC offset as an integer.
         // note the existence of fractional timezones (India, Central Australia, Newfoundland, etc.)
         const timeZoneName = dateFormat.formatToParts(d).find((p) => p.type === "timeZoneName").value;
-        return parseInt(timeZoneName.replace("GMT", "").split(":")[0], 10);
+        // a zero offset formats as bare "GMT" (no "+0"), which parses to NaN — treat it as 0
+        const offset = parseInt(timeZoneName.replace("GMT", "").split(":")[0], 10);
+        return Number.isNaN(offset) ? 0 : offset;
     }
 
     const year = date.getUTCFullYear();

--- a/sources/js/i18n/README.md
+++ b/sources/js/i18n/README.md
@@ -1,0 +1,65 @@
+# Translations (i18n)
+
+This folder holds the app's internationalization. Want to add or finish a
+translation? You only need to touch `locales/` — no other files.
+
+## How it works
+
+- **`i18n.js`** — the engine: locale detection, string lookup, fallback, the
+  task/cycle/moreInfo overlays, and the language switcher. You normally don't
+  edit this.
+- **`locales/<code>.js`** — one file per language. Files are auto-discovered, so
+  **adding a language is just dropping a new file in `locales/`**.
+- **`en.js` is canonical.** It holds the complete `ui` key set; every other
+  locale falls back to it. English task/cycle/moreInfo content lives in the
+  source data (`tasks.json`, `cycles.json`, `moreInfo.js`), not in `en.js`.
+- **Empty `""` = "not translated yet"** and falls back to English. So partial
+  translations are safe — translate as much as you want, leave the rest blank.
+- **A language only shows in the switcher once its `meta.ready` is `true`**
+  (English is always available). Mark it ready when it's good enough to ship.
+
+## Add a new language
+
+1. Copy an existing scaffold in `locales/` (e.g. `de.js`) to `<code>.js`, where
+   `<code>` is the language code (`it`, `pt-br`, `zh-hans`, …).
+2. Update `meta`: `{ code, label, htmlLang }`. `label` is the name shown in the
+   switcher (in its own language, e.g. `"Italiano"`); `htmlLang` is the
+   BCP-47 tag (e.g. `"pt-BR"`).
+3. Fill in the empty `""` strings (see the rules below).
+4. When it's ready to be shown, add `ready: true` to `meta`.
+
+## Finish or fix an existing language
+
+Open the `locales/<code>.js` file and replace `""` values with translations.
+Each file already lists every string that can be translated, grouped by section:
+
+| Section | What it is |
+|---|---|
+| `ui` | Interface strings (buttons, labels, messages). Keys must match `en.js`. |
+| `tasks` | Per-task text, keyed by task id. Only the fields a task actually has. |
+| `cycles` | Cycle table column names + cell text. **Keys are the English source string**, value is the translation. |
+| `moreInfo` | The long HTML "More Info" panels, keyed by task id. |
+
+## Rules
+
+- **Keep placeholders verbatim.** Tokens like `{name}`, `{timer}`, `{minutes}`,
+  `{time}`, `{version}` are filled in at runtime — copy them as-is.
+- **`&nbsp;` strings are injected as HTML.** Entities are fine in those, but
+  keep plain text in `aria.*` / title strings.
+- **Don't add keys that aren't in `en.js`** — stray/typo `ui` keys fail the
+  tests. Don't remove keys either; leave them `""` if untranslated.
+- **`cycles` keys must exactly match the English source** in `cycles.json`
+  (e.g. `"Strata Relay, Earth"`, not `"Relais"`), or the lookup won't match.
+- **Localized `location` strings that mention the base of operations** must use
+  the `baseOfOperations.label` value verbatim (the tests check this).
+
+## Test your changes
+
+```bash
+npm test          # watch mode
+npx vitest run     # one-shot
+```
+
+The `i18n` test suite checks every non-English locale for: all `en` keys
+present, no stray keys, placeholders preserved, real task ids, and
+base-of-operations consistency.

--- a/sources/js/i18n/i18n.js
+++ b/sources/js/i18n/i18n.js
@@ -1,0 +1,342 @@
+// --- sources/js/i18n/i18n.js ---
+// Locales are imported statically (not fetched at runtime) so Vite inlines them into the build.
+// `en` is canonical: complete `ui` dict, empty content overlays (English lives in the JSON/JS data).
+
+// Auto-discover every locale in ./locales/. Vite bundles eager-globbed files at
+// build time, so this still inlines into the single-file build (no runtime fetch).
+// To add a language: drop a `<code>.js` file in ./locales/ — no edits here needed.
+const localeModules = import.meta.glob("./locales/*.js", { eager: true, import: "default" });
+
+export const DEFAULT_LOCALE = "en";
+export const LOCALE_STORAGE_KEY = "warframeChecklistLocale";
+
+// registry keyed by each module's meta.code
+export const LOCALE_MODULES = {};
+for (const path in localeModules) {
+    const mod = localeModules[path];
+    if (mod && mod.meta && mod.meta.code) {
+        LOCALE_MODULES[mod.meta.code] = mod;
+    } else {
+        console.warn(`i18n: ignoring locale file '${path}' (missing meta.code).`);
+    }
+}
+
+const FALLBACK = LOCALE_MODULES[DEFAULT_LOCALE];
+
+// task fields the `tasks` overlay may translate
+const TASK_FIELDS = ["text", "location", "prereq", "info", "terminal", "npc"];
+
+// where contributors add/fill in translations (linked from the switcher footer)
+export const TRANSLATE_URL = "https://github.com/warframe-tools/Task-Checklist/tree/main/sources/js/i18n";
+
+// a locale appears in the switcher only once it's marked ready; en is always available
+const isVisibleLocale = (m) => m.meta.code === DEFAULT_LOCALE || m.meta.ready === true;
+
+// [{code, label}] for the selector — English first, then the rest alphabetically
+export const AVAILABLE_LOCALES = Object.values(LOCALE_MODULES)
+    .filter(isVisibleLocale)
+    .map((m) => ({ code: m.meta.code, label: m.meta.label }))
+    .sort((a, b) => (
+        a.code === DEFAULT_LOCALE ? -1
+        : b.code === DEFAULT_LOCALE ? 1
+        : a.label.localeCompare(b.label)
+    ));
+
+// map a browser language tag ("pt-BR", "zh-CN", "en-US"...) to a registered locale
+// code, or null if none fits. Each return is guarded so it only yields a real code:
+//   1. exact tag                 — "pt-br", "zh-hans" (if the browser sends the script)
+//   2. Chinese script via Intl   — "zh-CN"/"zh-TW"/"zh-HK"... -> "zh-hans"/"zh-hant"
+//   3. Portuguese                — we only ship Brazilian, so any "pt*" -> "pt-br"
+//   4. base language             — "en-US" -> "en"
+export function resolveLocale(tag) {
+    const lower = tag.toLowerCase();
+    if (Object.hasOwn(LOCALE_MODULES, lower)) { return lower; }
+
+    const base = lower.split("-")[0];
+
+    if (base === "zh") {
+        try {
+            const script = new Intl.Locale(tag).maximize().script; // "Hans" / "Hant"
+            const code = script === "Hant" ? "zh-hant" : "zh-hans";
+            if (Object.hasOwn(LOCALE_MODULES, code)) { return code; }
+        } catch (e) { /* fall through to base match */ }
+    }
+    if (base === "pt" && Object.hasOwn(LOCALE_MODULES, "pt-br")) { return "pt-br"; }
+
+    if (Object.hasOwn(LOCALE_MODULES, base)) { return base; }
+    return null;
+}
+
+function detectLocale() {
+    try {
+        const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
+        if (stored && Object.hasOwn(LOCALE_MODULES, stored)) {
+            return stored;
+        }
+    } catch (e) {
+        console.warn("i18n: could not read stored locale.", e);
+    }
+
+    try {
+        const langs = (navigator.languages && navigator.languages.length)
+            ? navigator.languages
+            : [navigator.language];
+        for (const lang of langs) {
+            if (!lang) { continue; }
+            const code = resolveLocale(lang);
+            // only auto-select a locale that's actually shown (translated) in the switcher
+            if (code && isVisibleLocale(LOCALE_MODULES[code])) {
+                return code;
+            }
+        }
+    } catch (e) {
+        console.warn("i18n: could not detect browser language.", e);
+    }
+
+    return DEFAULT_LOCALE;
+}
+
+let currentLocale = detectLocale();
+
+export function getLocale() {
+    return currentLocale;
+}
+
+export function getMeta() {
+    return LOCALE_MODULES[currentLocale].meta;
+}
+
+export function setLocale(code) {
+    if (!Object.hasOwn(LOCALE_MODULES, code)) {
+        console.warn(`i18n: unknown locale '${code}', ignoring.`);
+        return;
+    }
+    if (code === currentLocale) { return; }
+    try {
+        localStorage.setItem(LOCALE_STORAGE_KEY, code);
+    } catch (e) {
+        console.warn("i18n: could not persist locale preference.", e);
+    }
+    currentLocale = code;
+    location.reload(); // simplest way to re-render every string + all task content
+}
+
+// substitute {placeholder} tokens
+function interpolate(str, params) {
+    if (!params) { return str; }
+    return str.replace(/\{(\w+)\}/g, (match, key) => (
+        Object.hasOwn(params, key) ? params[key] : match
+    ));
+}
+
+// look up a UI string; fall back to en, then the key itself
+export function t(key, params) {
+    const dict = LOCALE_MODULES[currentLocale].ui;
+    let str;
+    // an empty string means "not translated yet" — fall through to the en fallback
+    if (dict && Object.hasOwn(dict, key) && dict[key] !== "") {
+        str = dict[key];
+    } else if (Object.hasOwn(FALLBACK.ui, key)) {
+        str = FALLBACK.ui[key];
+    } else {
+        console.warn(`i18n: missing translation key '${key}'.`);
+        str = key;
+    }
+    return interpolate(str, params);
+}
+
+// translated `location` strings must use baseOfOperations.label verbatim so makeInfoLine's swap-in matches
+export function baseOfOperationsHTML() {
+    return `<span class="tooltip" title="${t("baseOfOperations.tooltip")}">${t("baseOfOperations.label")}</span>`;
+}
+
+// overlay translated task text in place; no-op for en
+export function localizeTasks(tasks) {
+    const overlay = LOCALE_MODULES[currentLocale].tasks || {};
+
+    function walk(task) {
+        const fields = overlay[task.id];
+        if (fields) {
+            for (const field of TASK_FIELDS) {
+                // empty string = not translated yet; leave the English value in place
+                if (Object.hasOwn(fields, field) && fields[field] !== "") {
+                    task[field] = fields[field];
+                }
+            }
+        }
+        if (task.subtasks) { task.subtasks.forEach(walk); }
+    }
+
+    for (const section in tasks) {
+        tasks[section].forEach(walk);
+    }
+}
+
+// overlay translated cycle column names + cell text in place; no-op for en
+export function localizeCycles(cycles) {
+    const textMap = LOCALE_MODULES[currentLocale].cycles || {};
+    // empty string = not translated yet; keep the original cell/column text
+    const tr = (s) => (Object.hasOwn(textMap, s) && textMap[s] !== "" ? textMap[s] : s);
+
+    for (const id in cycles) {
+        for (const column of cycles[id].columns) {
+            if (column.name) { column.name = tr(column.name); }
+            for (const cell of column.order) {
+                if (cell.text) { cell.text = tr(cell.text); }
+            }
+        }
+    }
+}
+
+// translated moreInfo HTML for a task id, or undefined to keep the default
+export function getMoreInfo(id) {
+    const overlay = LOCALE_MODULES[currentLocale].moreInfo || {};
+    // empty string = not translated yet; undefined keeps the default English moreInfo
+    return Object.hasOwn(overlay, id) && overlay[id] !== "" ? overlay[id] : undefined;
+}
+
+// translate <html lang>, title, and elements tagged data-i18n / data-i18n-html / data-i18n-aria-label
+export function applyStaticTranslations(root = document) {
+    try {
+        document.documentElement.lang = getMeta().htmlLang;
+        document.title = t("document.title");
+    } catch (e) {
+        console.warn("i18n: could not set document lang/title.", e);
+    }
+
+    root.querySelectorAll("[data-i18n]").forEach((el) => {
+        el.textContent = t(el.dataset.i18n);
+    });
+    root.querySelectorAll("[data-i18n-html]").forEach((el) => {
+        el.innerHTML = t(el.dataset.i18nHtml);
+    });
+    root.querySelectorAll("[data-i18n-aria-label]").forEach((el) => {
+        el.setAttribute("aria-label", t(el.dataset.i18nAriaLabel));
+    });
+}
+
+const CHEVRON_SVG = `<svg class="lang-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>`;
+const CHECK_SVG = `<svg class="lang-check" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>`;
+const EXTERNAL_SVG = `<svg class="lang-ext" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>`;
+
+// custom button + listbox dropdown (a native <select> popup can't be themed)
+export function setupLanguageSwitcher(container) {
+    if (!container) { return; }
+    container.innerHTML = "";
+
+    const current = AVAILABLE_LOCALES.find((l) => l.code === currentLocale) || AVAILABLE_LOCALES[0];
+
+    const trigger = document.createElement("button");
+    trigger.type = "button";
+    trigger.className = "lang-trigger";
+    trigger.setAttribute("aria-haspopup", "listbox");
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.setAttribute("aria-controls", "lang-menu");
+    trigger.setAttribute("aria-label", t("aria.selectLanguage"));
+    trigger.innerHTML = `<span class="lang-current">${current.code.toUpperCase()}</span>${CHEVRON_SVG}`;
+
+    const menu = document.createElement("ul");
+    menu.id = "lang-menu";
+    menu.className = "lang-menu";
+    menu.setAttribute("role", "listbox");
+    menu.hidden = true;
+
+    for (const { code, label } of AVAILABLE_LOCALES) {
+        const selected = code === currentLocale;
+        const item = document.createElement("li");
+        item.className = "lang-option" + (selected ? " is-selected" : "");
+        item.setAttribute("role", "option");
+        item.setAttribute("aria-selected", selected ? "true" : "false");
+        item.dataset.code = code;
+        item.tabIndex = -1;
+        item.innerHTML = `<span class="lang-option-code">${code.toUpperCase()}</span><span class="lang-option-name">${label}</span>${selected ? CHECK_SVG : ""}`;
+        item.addEventListener("click", () => {
+            if (code !== currentLocale) { setLocale(code); } // reloads the page
+            else { close(); }
+        });
+        menu.appendChild(item);
+    }
+
+    // footer CTA: untranslated languages are hidden, so point people to where they can help
+    const help = document.createElement("li");
+    help.className = "lang-option lang-help";
+    help.setAttribute("role", "option");
+    help.tabIndex = -1;
+    help.innerHTML = `<span class="lang-option-name">${t("lang.helpTranslate")}</span>${EXTERNAL_SVG}`;
+    help.addEventListener("click", () => {
+        window.open(TRANSLATE_URL, "_blank", "noopener");
+        close();
+    });
+    menu.appendChild(help);
+
+    const options = () => [...menu.querySelectorAll(".lang-option")];
+
+    function open() {
+        menu.hidden = false;
+        trigger.setAttribute("aria-expanded", "true");
+        container.classList.add("open");
+        document.addEventListener("click", onOutside, true);
+        document.addEventListener("keydown", onKey, true);
+        (menu.querySelector(".is-selected") || options()[0])?.focus();
+    }
+    function close() {
+        menu.hidden = true;
+        trigger.setAttribute("aria-expanded", "false");
+        container.classList.remove("open");
+        document.removeEventListener("click", onOutside, true);
+        document.removeEventListener("keydown", onKey, true);
+    }
+    function onOutside(e) {
+        if (!container.contains(e.target)) { close(); }
+    }
+
+    // type-ahead: typing letters jumps to the matching language (by code or name)
+    let typeBuffer = "";
+    let typeTimer = null;
+    function typeahead(char) {
+        typeBuffer += char.toLowerCase();
+        if (typeTimer) { clearTimeout(typeTimer); }
+        typeTimer = setTimeout(() => { typeBuffer = ""; }, 500);
+        const match = options().find((o) => {
+            const code = (o.dataset.code || "").toLowerCase(); // help item has no code
+            const name = (o.querySelector(".lang-option-name")?.textContent || "").toLowerCase();
+            return code.startsWith(typeBuffer) || name.startsWith(typeBuffer);
+        });
+        match?.focus();
+    }
+
+    function onKey(e) {
+        const opts = options();
+        const idx = opts.indexOf(document.activeElement);
+        if (e.key === "Escape") { e.preventDefault(); close(); trigger.focus(); }
+        else if (e.key === "Tab") { close(); trigger.focus(); } // let focus continue from the trigger
+        else if (e.key === "ArrowDown") { e.preventDefault(); (opts[idx + 1] || opts[0]).focus(); }
+        else if (e.key === "ArrowUp") { e.preventDefault(); (opts[idx - 1] || opts[opts.length - 1]).focus(); }
+        else if (e.key === "Home") { e.preventDefault(); opts[0]?.focus(); }
+        else if (e.key === "End") { e.preventDefault(); opts[opts.length - 1]?.focus(); }
+        else if ((e.key === "Enter" || e.key === " ") && document.activeElement.classList.contains("lang-option")) {
+            e.preventDefault();
+            document.activeElement.click();
+        }
+        else if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) {
+            typeahead(e.key);
+        }
+    }
+
+    trigger.addEventListener("click", (e) => {
+        e.stopPropagation();
+        menu.hidden ? open() : close();
+    });
+
+    // open with the keyboard and land on the right end of the list
+    trigger.addEventListener("keydown", (e) => {
+        if (e.key !== "ArrowDown" && e.key !== "ArrowUp" && e.key !== "Home" && e.key !== "End") { return; }
+        e.preventDefault();
+        if (menu.hidden) { open(); }
+        const opts = options();
+        ((e.key === "ArrowUp" || e.key === "End") ? opts[opts.length - 1] : opts[0])?.focus();
+    });
+
+    container.appendChild(trigger);
+    container.appendChild(menu);
+}

--- a/sources/js/i18n/locales/de.js
+++ b/sources/js/i18n/locales/de.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/de.js ---
+// Deutsch — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Übersetzungsvorlage. Jeder Wert ist leer ("") und greift auf en.js / die
+// Quelldaten zurück, bis er ausgefüllt wird (siehe ../i18n.js). Trage Strings direkt
+// ein; ein leerer Wert "" behält die englische Vorgabe – Teilübersetzungen sind sicher.
+
+export default {
+    meta: { code: "de", label: "Deutsch", htmlLang: "de" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/en.js
+++ b/sources/js/i18n/locales/en.js
@@ -1,0 +1,123 @@
+// --- sources/js/i18n/locales/en.js ---
+/** Canonical locale. `ui` is the full key set every other locale falls back to.
+ * Content overlays (tasks/cycles/moreInfo) are empty here because English content
+ * already lives in tasks.json/cycles.json/moreInfo.js.
+ *
+ * Placeholders: tokens like {name}, {timer}, {minutes}, {time}, {version} are
+ * filled at runtime — keep them verbatim in translations. Strings using &nbsp;
+ * are injected as HTML; plain entities are fine there but not in aria/title text.
+ *
+ * Conventions: an empty string ("") means "not translated yet" and falls back to
+ * en.js / the source data, so partial locales are safe. A locale only appears in the
+ * language switcher once its meta has `ready: true` (en is always available).
+ */
+export default {
+    meta: { code: "en", label: "English", htmlLang: "en" },
+
+    ui: {
+        "document.title": "Warframe Task Checklist",
+        "app.title": "Warframe Task Checklist",
+        "app.description": "Track your daily, weekly, and other Warframe tasks.",
+
+        // aria-labels
+        "aria.toggleTheme": "Toggle theme",
+        "aria.openMenu": "Open menu",
+        "aria.closeError": "Close error message",
+        "aria.closeMenu": "Close menu",
+        "aria.closeSchedule": "Close schedule",
+        "aria.selectLanguage": "Select language",
+
+        // language switcher
+        "lang.helpTranslate": "Help translate on GitHub",
+
+        // error display banner
+        "error.copy": "Copy",
+        "error.copied": "Copied!",
+        "error.failed": "Failed",
+
+        // task sections
+        "section.daily": "Daily Tasks",
+        "section.weekly": "Weekly Tasks",
+        "section.other": "Other Tasks",
+        "section.hide": "Hide Section",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "(Resets ...)",
+        "countdown.loading": "(Loading...)",
+        "countdown.resetsInTimer": "(Resets in {timer})",
+        "countdown.availableForTimer": "(Available for {timer})",
+        "countdown.availableInTimer": "(Available in {timer})",
+        "countdown.dailyFallback": "(Resets 00:00 UTC)",
+        "countdown.weeklyFallback": "(Resets Mon 00:00 UTC)",
+
+        // save status
+        "save.saved": "Saved!",
+        "save.loading": "Loading...",
+        "save.storageNotice": "Your progress is saved locally.",
+        "save.lastSaved": "Last saved: {time}",
+        "save.never": "Never",
+
+        "reminder": "*Remember, you don't have to do everything! Prioritize tasks based on your current goals and progress.*",
+
+        // footer
+        "footer.appVersion": "App Version",
+        "footer.warframeVersion": "Warframe Version {version}",
+        "footer.license": "License (GPLv3)",
+        "footer.disclaimer": "This is an unofficial fan-made tool. Warframe and all related assets are the intellectual property of Digital Extremes Ltd. This project is not affiliated with, endorsed by, or sponsored by Digital Extremes Ltd.",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "Options",
+        "menu.resetDaily": "Reset Daily Checks",
+        "menu.resetWeekly": "Reset Weekly Checks",
+        "menu.resetAll": "Reset All Checks",
+        "menu.unhideAll": "Unhide All Tasks",
+        "menu.confirm": "Are you Sure?",
+
+        // cycle schedule dialog
+        "schedule.for": "Schedule for",
+        "schedule.date": "Date",
+        "schedule.now": "Now",
+        "schedule.cycleRepeats": "(Cycle Repeats)",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "Location",
+        "info.npc": "NPC",
+        "info.terminal": "Terminal",
+        "info.requirements": "Requirements",
+        "info.info": "Info",
+        "info.showSchedule": "Show&nbsp;Schedule",
+        "info.moreInfo": "More&nbsp;Info",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "This&nbsp;Week",
+        "cycle.today": "Today",
+        "cycle.currentCycle": "Current&nbsp;Cycle",
+        "cycle.nextCycle": "Next&nbsp;Cycle",
+
+        "baseOfOperations.label": "Base of Operations",
+        "baseOfOperations.tooltip": "Orbiter, Drifter's Camp, or Backroom",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "Toggle notifications for {name}",
+        "notif.hideTask": "Hide task: {name}",
+        "notif.leavingSoonTitle": "{name} Leaving Soon!",
+        "notif.leavingSoonBody": "Approximately {minutes} minutes remaining.",
+        "notif.resetTitle": "{name} has reset!",
+        "notif.resetBody": "Vendor stock may have updated.",
+        "notif.noSupport": "This browser does not support desktop notifications.",
+        "notif.denied": "Notification permission was denied. You can enable it in your browser settings.",
+        "notif.deniedPersist": "Notification permission has been denied. Please enable it in your browser settings if you wish to receive notifications.",
+
+        // save/load/startup errors
+        "errors.saveFailed": "Could not save progress.",
+        "errors.saveFailedQuota": "Could not save progress. Browser storage might be full.",
+        "errors.loadFailed": "Failed to load saved progress. Data might be corrupted.",
+        "errors.themeSaveFailed": "Could not save theme preference.",
+        "errors.critical": "A critical error occurred during application startup. Please check the console.",
+    },
+
+    // English content lives in tasks.json/cycles.json/moreInfo.js
+    tasks: {},
+    cycles: {},
+    moreInfo: {},
+};

--- a/sources/js/i18n/locales/es.js
+++ b/sources/js/i18n/locales/es.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/es.js ---
+// Español — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Plantilla de traducción. Cada valor está vacío ("") y recurre a en.js / los datos
+// de origen hasta que se rellena (consulta ../i18n.js). Escribe las cadenas aquí;
+// dejar un valor "" mantiene el texto en inglés, así que las traducciones parciales son seguras.
+
+export default {
+    meta: { code: "es", label: "Español", htmlLang: "es" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/fr.js
+++ b/sources/js/i18n/locales/fr.js
@@ -1,0 +1,517 @@
+// --- sources/js/i18n/locales/fr.js ---
+// Français — active translation. Empty ("") or missing keys fall back to en.js
+// (see ../i18n.js), so anything left blank shows the English default.
+//
+// Traduction active. Les clés vides ("") ou absentes reviennent à en.js
+// (voir ../i18n.js) ; tout ce qui est laissé vide affiche la valeur anglaise par défaut.
+import { iconURL } from "../../functions.js";
+
+function _factionIcon(name) {
+    const src = iconURL(`tasks/Syndicats/${name}`);
+    return `<img class="icon-filter inline-icon" src="${src}">`;
+}
+
+const _baseOfOperationsTooltip = `<span class="tooltip" title="Orbiter, Camp du Drifter ou Arrière-salle">Base d'opérations</span>`;
+
+const factions = `<p>Les Syndicats de Faction sont
+                 ${_factionIcon("FactionSigilRebels.png")}Le Méridien d'Acier,
+                 ${_factionIcon("FactionSigilJudge.png")}Les Arbitres d'Hexis,
+                 ${_factionIcon("FactionSigilOracle.png")}Céphalon Suda,
+                 ${_factionIcon("FactionSigilBusiness.png")}La Séquence Perrin,
+                 ${_factionIcon("FactionSigilAssassins.png")}Le Voile Rouge,
+                 et ${_factionIcon("FactionSigilChurch.png")}Le Nouveau Loka.</p>
+                 <p>Prêtez allégeance à un syndicat de faction depuis la console Syndicats de votre ${_baseOfOperationsTooltip}.</p>`;
+
+export default {
+    meta: { code: "fr", label: "Français", htmlLang: "fr", ready: true },
+
+    ui: {
+        "document.title": "Warframe Task Checklist",
+        "app.title": "Warframe Task Checklist",
+        "app.description": "Suivez vos tâches quotidiennes, hebdomadaires et autres dans Warframe.",
+
+        // aria-labels
+        "aria.toggleTheme": "Changer de thème",
+        "aria.openMenu": "Ouvrir le menu",
+        "aria.closeError": "Fermer le message d'erreur",
+        "aria.closeMenu": "Fermer le menu",
+        "aria.closeSchedule": "Fermer le calendrier",
+        "aria.selectLanguage": "Choisir la langue",
+
+        // language switcher
+        "lang.helpTranslate": "Aider à traduire sur GitHub",
+
+        // error display banner
+        "error.copy": "Copier",
+        "error.copied": "Copié !",
+        "error.failed": "Échec",
+
+        // task sections
+        "section.daily": "Tâches quotidiennes",
+        "section.weekly": "Tâches hebdomadaires",
+        "section.other": "Autres tâches",
+        "section.hide": "Masquer la section",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "(Réinitialisation...)",
+        "countdown.loading": "(Chargement...)",
+        "countdown.resetsInTimer": "(Réinitialisation dans {timer})",
+        "countdown.availableForTimer": "(Disponible pendant {timer})",
+        "countdown.availableInTimer": "(Disponible dans {timer})",
+        "countdown.dailyFallback": "(Réinitialisation à 00:00 UTC)",
+        "countdown.weeklyFallback": "(Réinitialisation lun. 00:00 UTC)",
+
+        // save status
+        "save.saved": "Enregistré !",
+        "save.loading": "Chargement...",
+        "save.storageNotice": "Votre progression est enregistrée localement.",
+        "save.lastSaved": "Dernier enregistrement : {time}",
+        "save.never": "Jamais",
+
+        "reminder": "*N'oubliez pas que vous n'êtes pas obligé de tout faire ! Priorisez les tâches en fonction de vos objectifs et de votre progression actuelle.*",
+
+        // footer
+        "footer.appVersion": "Version de l'application",
+        "footer.warframeVersion": "Version de Warframe {version}",
+        "footer.license": "Licence (GPLv3)",
+        "footer.disclaimer": "Ceci est un outil non officiel créé par des fans. Warframe et tous les éléments associés sont la propriété intellectuelle de Digital Extremes Ltd. Ce projet n'est ni affilié à Digital Extremes Ltd, ni approuvé ou sponsorisé par cette dernière.",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "Options",
+        "menu.resetDaily": "Réinitialiser les coches quotidiennes",
+        "menu.resetWeekly": "Réinitialiser les coches hebdomadaires",
+        "menu.resetAll": "Réinitialiser toutes les coches",
+        "menu.unhideAll": "Réafficher toutes les tâches",
+        "menu.confirm": "Êtes-vous sûr ?",
+
+        // cycle schedule dialog
+        "schedule.for": "Calendrier pour",
+        "schedule.date": "Date",
+        "schedule.now": "Maintenant",
+        "schedule.cycleRepeats": "(Le cycle se répète)",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "Lieu",
+        "info.npc": "PNJ",
+        "info.terminal": "Terminal",
+        "info.requirements": "Prérequis",
+        "info.info": "Info",
+        "info.showSchedule": "Afficher&nbsp;le&nbsp;calendrier",
+        "info.moreInfo": "Plus&nbsp;d'infos",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "Cette&nbsp;semaine",
+        "cycle.today": "Aujourd'hui",
+        "cycle.currentCycle": "Cycle&nbsp;actuel",
+        "cycle.nextCycle": "Prochain&nbsp;cycle",
+
+        "baseOfOperations.label": "Base d'opérations",
+        "baseOfOperations.tooltip": "Orbiter, Camp du Drifter ou Arrière-salle",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "Basculer les notifications pour {name}",
+        "notif.hideTask": "Masquer la tâche : {name}",
+        "notif.leavingSoonTitle": "{name} bientôt indisponible !",
+        "notif.leavingSoonBody": "Environ {minutes} minutes restantes.",
+        "notif.resetTitle": "{name} a été réinitialisé !",
+        "notif.resetBody": "Le stock du vendeur a peut-être été mis à jour.",
+        "notif.noSupport": "Ce navigateur ne prend pas en charge les notifications de bureau.",
+        "notif.denied": "L'autorisation des notifications a été refusée. Vous pouvez l'activer dans les paramètres de votre navigateur.",
+        "notif.deniedPersist": "L'autorisation des notifications a été refusée. Veuillez l'activer dans les paramètres de votre navigateur si vous souhaitez recevoir des notifications.",
+
+        // save/load/startup errors
+        "errors.saveFailed": "Impossible d'enregistrer la progression.",
+        "errors.saveFailedQuota": "Impossible d'enregistrer la progression. Le stockage du navigateur est peut-être plein.",
+        "errors.loadFailed": "Échec du chargement de la progression enregistrée. Les données sont peut-être corrompues.",
+        "errors.themeSaveFailed": "Impossible d'enregistrer la préférence de thème.",
+        "errors.critical": "Une erreur critique s'est produite au démarrage de l'application. Veuillez vérifier la console.",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "Connexion : Récupérez la récompense de connexion quotidienne." },
+        daily_craft_forma: {
+            text: "Fabrication (Forma) : Commencez la fabrication d'un nouveau Forma (et récupérez ceux qui sont terminés).",
+            location: "Base d'opérations",
+            terminal: "Fonderie",
+        },
+        daily_craft_other: {
+            text: "Fabrication (Autre) : Fabriquez d'autres ressources ou objets quotidiens à l'aide de plans réutilisables (consultez la Fonderie ou l'application compagnon).",
+            location: "Base d'opérations",
+            terminal: "Fonderie",
+        },
+        daily_first_win_bonus: {
+            text: "Bonus quotidien de première victoire : Obtenez le double des crédits de base sur votre première mission.",
+            location: "Base d'opérations",
+            terminal: "Navigation",
+        },
+        daily_syndicate_gain: {
+            text: "Syndicats de Faction : Atteignez le plafond de réputation quotidien avec le(s) Syndicat(s) auxquels vous êtes affilié.",
+            prereq: "Palier de maîtrise 3",
+            info: "Gagnez de l'affinité dans n'importe quelle mission pour augmenter votre réputation de faction",
+        },
+        daily_syndicate_spend: {
+            text: "Syndicats de Faction : Si votre réputation est au maximum, dépensez-la (packs de Reliques, packs de Vosfor, etc.).",
+            location: "Base d'opérations / N'importe quel Relais",
+            terminal: "Syndicats",
+            prereq: "Palier de maîtrise 3",
+        },
+        daily_world_syndicate_parent: { text: "Syndicats du monde (réputation)" },
+        daily_world_syndicate_simaris: { text: "Céphalon Simaris", location: "N'importe quel Relais" },
+        daily_world_syndicate_ostron: { text: "Ostron", location: "Cetus, Terre", prereq: "Saya's Vigil" },
+        daily_world_syndicate_quills: { text: "Les Plumes", location: "Cetus, Terre", prereq: "La Guerre Intérieure" },
+        daily_world_syndicate_solaris: { text: "Union Solaris", location: "Fortuna, Vénus", prereq: "Vox Solaris (Quête)" },
+        daily_world_syndicate_vox: { text: "Vox Solaris", location: "Fortuna, Vénus", prereq: "La Guerre Intérieure" },
+        daily_world_syndicate_ventkids: { text: "Orphelins des Conduits", location: "Fortuna, Vénus", prereq: "Vox Solaris (Quête)" },
+        daily_world_syndicate_entrati: { text: "Entrati", location: "Necralisk, Deimos", prereq: "Cœur de Deimos" },
+        daily_world_syndicate_necraloid: { text: "Necraloïde", location: "Necralisk, Deimos", prereq: "La Guerre Intérieure" },
+        daily_world_syndicate_holdfasts: { text: "Les Irréductibles", location: "Chrysalith, Zariman", prereq: "Les Anges du Zariman" },
+        daily_world_syndicate_cavia: { text: "Cavia", location: "Sanctum Anatomica, Deimos", prereq: "Murmures dans les murs" },
+        daily_world_syndicate_hex: { text: "L'Hexagone", location: "Höllvania Central Mall", prereq: "L'Hexagone (Quête)" },
+        daily_sortie: {
+            text: "Sortie : Terminez les 3 missions quotidiennes de la Sortie.",
+            location: "Base d'opérations",
+            terminal: "Navigation",
+            prereq: "La Guerre Intérieure",
+        },
+        daily_focus: {
+            text: "Focus : Atteignez le maximum de gain de Focus quotidien (par ex. via le Sanctuary Onslaught).",
+            prereq: "Le Second Rêve",
+        },
+        daily_steel_path: {
+            text: "Incursions de la Route de l'Acier : Terminez les missions quotidiennes de la Route de l'Acier pour de l'Essence d'Acier.",
+            prereq: "Route de l'Acier débloqué",
+        },
+        daily_kim_parent: {
+            text: "KIM : Terminez les conversations quotidiennes avec les Protoframes.",
+            location: "Base d'opérations",
+            terminal: "POM-2 PC",
+        },
+        daily_kim_hex_parent: { text: "L'Hexagone", prereq: "L'Hexagone (Quête)" },
+        daily_kim_arthur: { text: "Broadsword (Arthur)" },
+        daily_kim_eleanor: { text: "Salem (Eleanor)" },
+        daily_kim_lettie: { text: "Belladona (Lettie)" },
+        daily_kim_amir: { text: "H16h V0l7463 (Amir)" },
+        daily_kim_aoi: { text: "xX GLIMMER Xx (Aoi)" },
+        daily_kim_quincy: { text: "Soldja1Shot1kil (Quincy)" },
+        daily_kim_roundtable_parent: { text: "The Roundtable", prereq: "L'Hexagone (Quête) Finale" },
+        daily_kim_flare: { text: "Liminus_Star (Flare)", prereq: "Rang 4 L'Hexagone" },
+        daily_kim_minerva_velimir: { text: "MomToxicated & PapaPolar (Minerva & Velimir)", prereq: "Rang 5 L'Hexagone" },
+        daily_kim_kaya: { text: "KOLTrial_5115 (Kaya)", prereq: "Rang 5 L'Hexagone" },
+        daily_kim_devils_triad_parent: { text: "The Devil's Triad", prereq: "L'Ancienne Paix" },
+        daily_kim_marie: { text: "Marie" },
+        daily_kim_roathe: { text: "Roathe" },
+        daily_kim_lyon: { text: "Lyon", prereq: "\"Apprécié\" par Marie" },
+        daily_vendors: { text: "Vendeurs" },
+        daily_acrithis: {
+            text: "Acrithis : Consultez l'offre quotidienne d'Arcanes et de scènes Captura.",
+            location: "Duviri/Dormizone",
+            npc: "Acrithis",
+            prereq: "Inhérences du Voyageur : Opportunité, rang 9 (pour les Arcanes)",
+        },
+        daily_ticker_crew: {
+            text: "Ticker : Consultez l'équipage Railjack disponible à l'embauche.",
+            location: "Fortuna, Vénus",
+            npc: "Ticker",
+            prereq: "Marée Montante & Inhérences de Commandement 1",
+        },
+        daily_marie: {
+            text: "Marie : Achetez des mods Tektolyst, des arcanes et des ressources Perita/Descendia.",
+            location: "La Cathédrale (Sanctum Anatomica, Deimos)",
+            npc: "Marie",
+            prereq: "L'Ancienne Paix",
+        },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "Nightwave : Terminez les missions hebdomadaires Nightwave pertinentes." },
+        weekly_nightwave_spend: { text: "Nightwave (dépenser) : Dépensez vos crédits Nightwave si nécessaire (mods d'Aura, Catalysts/Reactors, etc.)." },
+        weekly_ayatan: {
+            text: "Chasse au trésor Ayatan : Terminez la mission hebdomadaire de Maroo pour obtenir une sculpture Ayatan",
+            location: "Le Bazar de Maroo, Mars",
+            npc: "Maroo",
+        },
+        weekly_clem: {
+            text: "Aider Clem : Aidez Clem dans sa survie hebdomadaire, sinon il mourra.",
+            location: "N'importe quel Relais",
+            npc: "Darvo",
+            prereq: "Un Homme Peu Bavard",
+        },
+        weekly_kahl_garrison: {
+            text: "Briser Narmer : Terminez la mission hebdomadaire de Kahl pour du Stock.",
+            location: "Drifter's Camp, Terre",
+            npc: "Kahl",
+            prereq: "Brise-Voile",
+        },
+        weekly_archon_hunt: {
+            text: "Chasse aux Archontes : Terminez la Chasse aux Archontes hebdomadaire pour obtenir un Fragment d'Archonte garanti.",
+            location: "Base d'opérations",
+            terminal: "Navigation",
+            prereq: "La Nouvelle Guerre",
+        },
+        weekly_duviri_circuit: {
+            text: "Duviri Circuit (normal) : Consultez les options de Warframe hebdomadaires et lancez le Circuit si vous le souhaitez.",
+            location: "Base d'opérations/Dormizone",
+            terminal: "Navigation",
+            prereq: "Le Paradoxe Duviri",
+        },
+        weekly_duviri_circuit_sp: {
+            text: "Duviri Circuit (Route de l'Acier) : Consultez les Incarnon Adapters hebdomadaires et lancez le Circuit si vous le souhaitez.",
+            location: "Base d'opérations/Dormizone",
+            terminal: "Navigation",
+            prereq: "Route de l'Acier débloqué & Le Paradoxe Duviri",
+        },
+        weekly_search_pulses: { text: "Impulsions de Recherche : Utilisez vos 5 Impulsions de Recherche hebdomadaires sur les Netracells et les Archimédées." },
+        weekly_netracells: {
+            text: "Netracells : Terminez jusqu'à 5 missions Netracell hebdomadaires pour avoir des chances d'obtenir un Fragment d'Archonte.",
+            location: "Sanctum Anatomica, Deimos",
+            npc: "Tagfer",
+            prereq: "Murmures dans les murs",
+            info: "Coûte 1 Impulsion de Recherche par mission réussie",
+        },
+        weekly_eda: {
+            text: "Archimédée Profonde : Tentez l'Archimédée d'Élite hebdomadaire pour de grandes chances d'obtenir un Fragment d'Archonte (réservé au endgame).",
+            location: "Sanctum Anatomica, Deimos",
+            npc: "Necraloid",
+            prereq: "Rang 5 Cavia",
+            info: "Coûte 2 Impulsions de Recherche pour le débloquer pour la semaine",
+        },
+        weekly_eta: {
+            text: "Archimédée Temporelle : Tentez l'Archimédée d'Élite hebdomadaire pour de grandes chances d'obtenir un Fragment d'Archonte (réservé au endgame).",
+            location: "Höllvania Central Mall",
+            npc: "Kaya",
+            prereq: "Rang 5 L'Hexagone",
+            info: "Coûte 2 Impulsions de Recherche pour le débloquer pour la semaine",
+        },
+        weekly_calendar: {
+            text: "Calendrier 1999 : Terminez les tâches hebdomadaires du calendrier.",
+            location: "Base d'opérations",
+            terminal: "POM-2 PC",
+            prereq: "L'Hexagone",
+        },
+        weekly_invigorations: {
+            text: "Helminth : Utilisez les Invigorations hebdomadaires.",
+            location: "Base d'opérations",
+            npc: "Helminth",
+            prereq: "Rang 5 Entrati",
+        },
+        weekly_descendia: {
+            text: "La Descendia (normal) : Mode de jeu hebdomadaire de la Tour pour diverses ressources.",
+            location: "Ténèbres Réfractaires (Base d'opérations)",
+            terminal: "Navigation",
+        },
+        weekly_descendia_sp: {
+            text: "La Descendia (Route de l'Acier) : Mode de jeu hebdomadaire de la Tour pour diverses ressources.",
+            location: "Ténèbres Réfractaires (Base d'opérations)",
+            terminal: "Navigation",
+        },
+        weekly_vendors: { text: "Vendeurs" },
+        weekly_iron_wake: {
+            text: "Paladino : Échangez des Brisure Riven.",
+            location: "Iron Wake, Terre",
+            npc: "Paladino",
+            prereq: "Le Fardeau de Harrow",
+        },
+        weekly_yonta: {
+            text: "Archimédienne Yonta : Achetez du Kuva hebdomadaire avec des Plumes du Néant.",
+            location: "Chrysalith, Zariman",
+            npc: "Yonta",
+            prereq: "Les Anges du Zariman",
+        },
+        weekly_acrithis: {
+            text: "Acrithis : Consultez les marchandises et dépensez vos Pathos Clamps si vous le souhaitez (Catalysts/Reactors recommandés si besoin). Achetez du Kuva avec des Scuttler Husks.",
+            location: "Duviri/Dormizone",
+            npc: "Acrithis",
+            prereq: "Le Paradoxe Duviri",
+        },
+        weekly_teshin: {
+            text: "Teshin (Route de l'Acier) : Consultez la boutique Essence d'Acier de Teshin, notamment pour la rotation de Forma Umbra toutes les 8 semaines.",
+            location: "N'importe quel Relais",
+            npc: "Teshin",
+            prereq: "Route de l'Acier débloqué",
+        },
+        weekly_bird3: {
+            text: "Bird 3 : Achetez le Fragment d'Archonte hebdomadaire pour 30k de réputation Cavia.",
+            location: "Sanctum Anatomica, Deimos",
+            npc: "Bird 3",
+            prereq: "Rang 5 Cavia",
+        },
+        weekly_nightcap: {
+            text: "Nightcap : Échangez du Fergolyte contre du Kuva et une sculpture Ayatan.",
+            location: "Fortuna, Vénus",
+            npc: "Nightcap",
+            prereq: "La Nouvelle Guerre",
+        },
+        weekly_zorba: {
+            text: "Aspirant Zorba : Échangez de l'Atramentum contre du Kuva.",
+            location: "N'importe quel Relais",
+            npc: "Aspirant Zorba",
+            prereq: "Le Fardeau de Harrow",
+        },
+
+        // --- other ---
+        other_baro: {
+            text: "Baro Ki'Teer : Consultez l'inventaire de Baro Ki'Teer et achetez les objets souhaités avec des Ducats (échangez des pièces Prime contre des Ducats).",
+            location: "Relais avec le symbole",
+            npc: "Baro Ki'Teer",
+        },
+        other_grandmother_tokens: {
+            text: "Mend the Family : Achetez des Family Tokens auprès de Grandmother.",
+            location: "Necralisk, Deimos",
+            prereq: "Cœur de Deimos",
+        },
+        other_yonta_voidplumes: {
+            text: "Échanger contre des Plumes du Néant",
+            location: "Chrysalith, Zariman",
+            npc: "Yonta",
+            prereq: "Les Anges du Zariman",
+        },
+        other_loid_voca: {
+            text: "Échanger contre des Voca",
+            location: "Sanctum Anatomica, Deimos",
+            npc: "Loid",
+            prereq: "Murmures dans les murs",
+        },
+        other_glast: {
+            text: "Armes Tenet : Consultez la boutique d'Ergo Glast pour de bons bonus de valence.",
+            location: "N'importe quel Relais",
+            npc: "Ergo Glast",
+            prereq: "The Archwing + Palier de maîtrise 14",
+        },
+        other_eleanor: {
+            text: "Armes Coda : Consultez la boutique d'Eleanor pour de bons bonus de valence.",
+            location: "Höllvania Central Mall",
+            npc: "Eleanor Nightingale",
+            prereq: "L'Hexagone (Quête)",
+        },
+    },
+
+    cycles: {
+        // column names
+        "Item": "Objet",
+        "Tileset": "Tileset",
+        "Boss": "Boss",
+        "Season": "Saison",
+        "Mission": "Mission",
+        "Price": "Prix",
+        "Location": "Lieu",
+        "Increased Spawns": "Apparitions accrues",
+        "Items": "Objets",
+        "Coda Weapons": "Armes Coda",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "Épave orokin (Deimos)",
+        "Orokin Tower (Void)": "Tour orokin (Le Néant)",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "Spatioport (Orb Vallis, Vénus)",
+        "Grineer Forest (Earth)": "Forêt grineer (Terre)",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "Colonie grineer (Mars)",
+        "Corpus Gas City (Jupiter)": "Cité gazière corpus (Jupiter)",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "Plans pour Excalibur, Trinity ou Ember",
+        "Blueprints for Loki, Mag, or Rhino": "Plans pour Loki, Mag ou Rhino",
+        "Blueprints for Ash, Frost, or Nyx": "Plans pour Ash, Frost ou Nyx",
+        "Blueprints for Saryn, Vauban, or Nova": "Plans pour Saryn, Vauban ou Nova",
+        "Blueprints for Nekros, Valkyr, or Oberon": "Plans pour Nekros, Valkyr ou Oberon",
+        "Blueprints for Hydroid, Mirage, or Limbo": "Plans pour Hydroid, Mirage ou Limbo",
+        "Blueprints for Mesa, Chroma, or Atlas": "Plans pour Mesa, Chroma ou Atlas",
+        "Blueprints for Ivara, Inaros, or Titania": "Plans pour Ivara, Inaros ou Titania",
+        "Blueprints for Nidus, Octavia, or Harrow": "Plans pour Nidus, Octavia ou Harrow",
+        "Blueprints for Gara, Khora, or Revenant": "Plans pour Gara, Khora ou Revenant",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "Plans pour Garuda, Baruuk ou Hildryn",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "Incarnon Adapters pour Braton, Kunai, Lato, Paris et Skana",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "Incarnon Adapters pour Angstrum, Anku, Boar, Gammacor et Gorgon",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "Incarnon Adapters pour Bo, Furax, Furis, Latron et Strun",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "Incarnon Adapters pour Boltor, Bronco, Ceramic Dagger, Lex et Magistar",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "Incarnon Adapters pour Atomos, Dual Ichor, Dual Toxocyst, Miter et Torid",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "Incarnon Adapters pour Ack & Brunt, Burston, Nami Solo, Soma et Vasto",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "Incarnon Adapters pour Despair, Dread, Hate, Sibear et Zylok",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "Incarnon Adapters pour Cestra, Dera, Okina, Sicarus et Sybaris",
+
+        // weekly_calendar seasons
+        "Winter": "Hiver",
+        "Spring": "Printemps",
+        "Summer": "Été",
+        "Autumn": "Automne",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "❄️ Eximus Arctique",
+        "🟢 Jade Light Eximus": "🟢 Eximus Lumière de Jade",
+        "🔥 Arson Eximus": "🔥 Eximus Incendiaire",
+        "🧲 Energy Leech Eximus": "🧲 Eximus Sangsue d'Énergie",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "Forma Umbra (Schéma)",
+        "50,000 Kuva": "50 000 Kuva",
+        "Kitgun Riven Mod": "Mod Riven de Kitgun",
+        "3x Built Forma": "3 Forma fabriqués",
+        "Zaw Riven Mod": "Mod Riven de Zaw",
+        "30,000 Endo": "30 000 Endo",
+        "Rifle Riven Mod": "Mod Riven de Fusil",
+        "Shotgun Riven Mod": "Mod Riven de Fusil à Pompe",
+
+        // other_baro locations
+        "Strata Relais, Earth": "Relais Strata, Terre",
+        "Larunda Relais, Mercury": "Relais Larunda, Mercure",
+        "Kronia Relais, Saturn": "Relais Kronia, Saturne",
+        "Orcus Relais, Pluto (MR 8+)": "Relais Orcus, Pluton (PM 8+)",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: `<p>Votre première mission terminée après la réinitialisation quotidienne octroie le double des <em>crédits de base récompensés</em>. Cela ne s'applique qu'au bonus de fin de mission, et <strong>non</strong> aux crédits ramassés pendant la mission.</p>
+    <p>Cela ne s'applique <strong>pas</strong> non plus aux types de mission et lieux suivants :</p>
+    <ul>
+        <li><strong>The Index</strong></li>
+        <li>Mondes ouverts (y compris Profit Taker)</li>
+        <li>Zariman</li>
+        <li>Höllvania (y compris les coffres Techrot)</li>
+    </ul>
+    <p>Terminer l'une de ces missions consommera le bonus sans octroyer de crédits supplémentaires.</p>
+    <p>Le bonus <strong>se cumule</strong> avec les Credit Boosters, les Credit Blessings et les événements à crédits doublés. Se rendre dans un Relais ou une autre zone hors mission ne consomme <strong>pas</strong> le bonus.</p>
+    <p>Voici quelques bonnes missions pour l'utiliser :</p>
+    <table>
+        <thead><tr>
+            <th>Nom</th>
+            <th>Type</th>
+            <th>Crédits de base</th>
+            <th>Niveau ennemi</th>
+        </tr></thead>
+        <tbody>
+            <tr>
+                <td>Tikal, Terre</td>
+                <td>Dark Sector Excavation</td>
+                <td>13 500</td>
+                <td>6 - 16</td>
+            </tr>
+            <tr>
+                <td>Gabii, Cérès</td>
+                <td>Dark Sector Survival</td>
+                <td>22 400</td>
+                <td>15 - 25</td>
+            </tr>
+            <tr>
+                <td>Bendar Cluster, Terre Proxima</td>
+                <td>Railjack Skirmish</td>
+                <td>48 800</td>
+                <td>29 - 36</td>
+            </tr>
+            <tr>
+                <td>Sabmir Cloud, Voile Proxima</td>
+                <td>Railjack Spy</td>
+                <td>156 600</td>
+                <td>56 - 60</td>
+            </tr>
+        </tbody>
+    </table>
+    <p>Consultez <a href="https://wiki.warframe.com/w/Daily_Tribute#Daily_First_Win_Bonus">Daily First Win Bonus</a>, <a href="https://wiki.warframe.com/w/Dark_Sectors">Dark Sectors</a> et <a href="https://wiki.warframe.com/w/Mission#Locations">Mission</a> sur le wiki pour plus de détails.</p>
+    <p>(Il existe actuellement un bug visuel où les crédits bonus n'apparaissent pas sur l'écran de fin de mission. Ils <em>sont</em> toutefois bien ajoutés à votre compte.)</p>`,
+
+        daily_syndicate_gain: factions,
+        daily_syndicate_spend: factions,
+    },
+};

--- a/sources/js/i18n/locales/it.js
+++ b/sources/js/i18n/locales/it.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/it.js ---
+// Italiano — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Modello di traduzione. Ogni valore è vuoto ("") e ricade su en.js / i dati
+// originali finché non viene compilato (vedi ../i18n.js). Inserisci le stringhe qui;
+// lasciare un valore "" mantiene il testo inglese, quindi le traduzioni parziali sono sicure.
+
+export default {
+    meta: { code: "it", label: "Italiano", htmlLang: "it" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/ja.js
+++ b/sources/js/i18n/locales/ja.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/ja.js ---
+// 日本語 — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// 翻訳テンプレート。各値は空 ("") で、入力されるまで en.js / 元データに
+// フォールバックします（../i18n.js を参照）。文字列はその場で入力してください。
+// 値を "" のままにすると英語の既定値が使われるため、部分的な翻訳でも安全です。
+
+export default {
+    meta: { code: "ja", label: "日本語", htmlLang: "ja" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/ko.js
+++ b/sources/js/i18n/locales/ko.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/ko.js ---
+// 한국어 — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// 번역 템플릿. 모든 값은 비어 있으며("") 입력하기 전까지 en.js / 원본
+// 데이터로 폴백됩니다(../i18n.js 참고). 문자열을 그 자리에 입력하세요.
+// 값을 ""로 두면 영어 기본값이 유지되므로 부분 번역도 안전합니다.
+
+export default {
+    meta: { code: "ko", label: "한국어", htmlLang: "ko" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/pl.js
+++ b/sources/js/i18n/locales/pl.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/pl.js ---
+// Polski — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Szablon tłumaczenia. Każda wartość jest pusta ("") i korzysta z en.js / danych
+// źródłowych, dopóki nie zostanie uzupełniona (zob. ../i18n.js). Wpisuj ciągi na
+// miejscu; pusta wartość "" zachowuje angielski tekst, więc częściowe tłumaczenia są bezpieczne.
+
+export default {
+    meta: { code: "pl", label: "Polski", htmlLang: "pl" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/pt-br.js
+++ b/sources/js/i18n/locales/pt-br.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/pt-br.js ---
+// Português-Br — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Modelo de tradução. Cada valor está vazio ("") e recorre a en.js / aos dados de
+// origem até ser preenchido (veja ../i18n.js). Preencha as strings aqui; deixar um
+// valor "" mantém o padrão em inglês, então traduções parciais são seguras.
+
+export default {
+    meta: { code: "pt-br", label: "Português-Br", htmlLang: "pt-BR" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/ru.js
+++ b/sources/js/i18n/locales/ru.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/ru.js ---
+// Русский — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Шаблон перевода. Каждое значение пустое ("") и использует en.js / исходные
+// данные, пока не заполнено (см. ../i18n.js). Вписывайте строки на месте; пустое
+// значение "" сохраняет английский вариант, поэтому частичный перевод безопасен.
+
+export default {
+    meta: { code: "ru", label: "Русский", htmlLang: "ru" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/th.js
+++ b/sources/js/i18n/locales/th.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/th.js ---
+// ไทย — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// เทมเพลตการแปล ทุกค่าเป็นค่าว่าง ("") และจะถอยกลับไปใช้ en.js / ข้อมูลต้นฉบับ
+// จนกว่าจะกรอก (ดู ../i18n.js) กรอกสตริงในตำแหน่งนั้นได้เลย การปล่อยค่าไว้เป็น ""
+// จะคงค่าเริ่มต้นภาษาอังกฤษไว้ ดังนั้นการแปลบางส่วนจึงปลอดภัย
+
+export default {
+    meta: { code: "th", label: "ไทย", htmlLang: "th" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/tr.js
+++ b/sources/js/i18n/locales/tr.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/tr.js ---
+// Türkçe — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Çeviri şablonu. Her değer boştur ("") ve doldurulana kadar en.js / kaynak
+// verilere geri döner (bkz. ../i18n.js). Dizeleri yerinde doldurun; "" değeri
+// İngilizce varsayılanı korur, bu yüzden kısmi çeviriler güvenlidir.
+
+export default {
+    meta: { code: "tr", label: "Türkçe", htmlLang: "tr" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/uk.js
+++ b/sources/js/i18n/locales/uk.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/uk.js ---
+// Українська — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// Шаблон перекладу. Кожне значення порожнє ("") і використовує en.js / вихідні
+// дані, доки не заповнене (див. ../i18n.js). Вписуйте рядки на місці; порожнє
+// значення "" зберігає англійський варіант, тож частковий переклад безпечний.
+
+export default {
+    meta: { code: "uk", label: "Українська", htmlLang: "uk" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/zh-hans.js
+++ b/sources/js/i18n/locales/zh-hans.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/zh-hans.js ---
+// 简体中文 — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// 翻译模板。每个值均为空 ("")，在填写之前会回退到 en.js / 源数据
+//（见 ../i18n.js）。请就地填写字符串；将值留空 "" 会保留英文默认值，
+// 因此部分翻译也是安全的。
+
+export default {
+    meta: { code: "zh-hans", label: "简体中文", htmlLang: "zh-Hans" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/i18n/locales/zh-hant.js
+++ b/sources/js/i18n/locales/zh-hant.js
@@ -1,0 +1,304 @@
+// --- sources/js/i18n/locales/zh-hant.js ---
+// 繁體中文 — translation scaffold. Every value is empty ("") and falls back to
+// en.js / the source data until filled in (see ../i18n.js). Fill strings in place;
+// leaving a value "" keeps the English default, so partial translations are safe.
+//
+// 翻譯範本。每個值皆為空 ("")，在填寫之前會回退到 en.js / 原始資料
+//（見 ../i18n.js）。請就地填寫字串；將值留空 "" 會保留英文預設值，
+// 因此部分翻譯也是安全的。
+
+export default {
+    meta: { code: "zh-hant", label: "繁體中文", htmlLang: "zh-Hant" },
+
+    ui: {
+        "document.title": "",
+        "app.title": "",
+        "app.description": "",
+
+        // aria-labels
+        "aria.toggleTheme": "",
+        "aria.openMenu": "",
+        "aria.closeError": "",
+        "aria.closeMenu": "",
+        "aria.closeSchedule": "",
+        "aria.selectLanguage": "",
+
+        // language switcher
+        "lang.helpTranslate": "",
+
+        // error display banner
+        "error.copy": "",
+        "error.copied": "",
+        "error.failed": "",
+
+        // task sections
+        "section.daily": "",
+        "section.weekly": "",
+        "section.other": "",
+        "section.hide": "",
+
+        // reset / countdown timers ({timer} is the highlighted countdown span)
+        "countdown.resetEllipsis": "",
+        "countdown.loading": "",
+        "countdown.resetsInTimer": "",
+        "countdown.availableForTimer": "",
+        "countdown.availableInTimer": "",
+        "countdown.dailyFallback": "",
+        "countdown.weeklyFallback": "",
+
+        // save status
+        "save.saved": "",
+        "save.loading": "",
+        "save.storageNotice": "",
+        "save.lastSaved": "",
+        "save.never": "",
+
+        "reminder": "",
+
+        // footer
+        "footer.appVersion": "",
+        "footer.warframeVersion": "",
+        "footer.license": "",
+        "footer.disclaimer": "",
+
+        // options menu + reset confirmation buttons
+        "menu.options": "",
+        "menu.resetDaily": "",
+        "menu.resetWeekly": "",
+        "menu.resetAll": "",
+        "menu.unhideAll": "",
+        "menu.confirm": "",
+
+        // cycle schedule dialog
+        "schedule.for": "",
+        "schedule.date": "",
+        "schedule.now": "",
+        "schedule.cycleRepeats": "",
+
+        // info line (labels are icon tooltips; buttons use &nbsp; to avoid wrapping)
+        "info.location": "",
+        "info.npc": "",
+        "info.terminal": "",
+        "info.requirements": "",
+        "info.info": "",
+        "info.showSchedule": "",
+        "info.moreInfo": "",
+
+        // current-cycle prefixes (rendered as HTML; &nbsp; keeps them on one line)
+        "cycle.thisWeek": "",
+        "cycle.today": "",
+        "cycle.currentCycle": "",
+        "cycle.nextCycle": "",
+
+        "baseOfOperations.label": "",
+        "baseOfOperations.tooltip": "",
+
+        // desktop notifications + permission prompts
+        "notif.toggleFor": "",
+        "notif.hideTask": "",
+        "notif.leavingSoonTitle": "",
+        "notif.leavingSoonBody": "",
+        "notif.resetTitle": "",
+        "notif.resetBody": "",
+        "notif.noSupport": "",
+        "notif.denied": "",
+        "notif.deniedPersist": "",
+
+        // save/load/startup errors
+        "errors.saveFailed": "",
+        "errors.saveFailedQuota": "",
+        "errors.loadFailed": "",
+        "errors.themeSaveFailed": "",
+        "errors.critical": "",
+    },
+
+    tasks: {
+        // --- daily ---
+        daily_login: { text: "" },
+        daily_craft_forma: { text: "", location: "", terminal: "" },
+        daily_craft_other: { text: "", location: "", terminal: "" },
+        daily_first_win_bonus: { text: "", location: "", terminal: "" },
+        daily_syndicate_gain: { text: "", prereq: "", info: "" },
+        daily_syndicate_spend: { text: "", location: "", terminal: "", prereq: "" },
+        daily_world_syndicate_parent: { text: "" },
+        daily_world_syndicate_simaris: { text: "", location: "" },
+        daily_world_syndicate_ostron: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_quills: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_solaris: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_vox: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_ventkids: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_entrati: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_necraloid: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_holdfasts: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_cavia: { text: "", location: "", prereq: "" },
+        daily_world_syndicate_hex: { text: "", location: "", prereq: "" },
+        daily_sortie: { text: "", location: "", terminal: "", prereq: "" },
+        daily_focus: { text: "", prereq: "" },
+        daily_steel_path: { text: "", prereq: "" },
+        daily_kim_parent: { text: "", location: "", terminal: "" },
+        daily_kim_hex_parent: { text: "", prereq: "" },
+        daily_kim_arthur: { text: "" },
+        daily_kim_eleanor: { text: "" },
+        daily_kim_lettie: { text: "" },
+        daily_kim_amir: { text: "" },
+        daily_kim_aoi: { text: "" },
+        daily_kim_quincy: { text: "" },
+        daily_kim_roundtable_parent: { text: "", prereq: "" },
+        daily_kim_flare: { text: "", prereq: "" },
+        daily_kim_minerva_velimir: { text: "", prereq: "" },
+        daily_kim_kaya: { text: "", prereq: "" },
+        daily_kim_devils_triad_parent: { text: "", prereq: "" },
+        daily_kim_marie: { text: "" },
+        daily_kim_roathe: { text: "" },
+        daily_kim_lyon: { text: "", prereq: "" },
+        daily_vendors: { text: "" },
+        daily_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        daily_ticker_crew: { text: "", location: "", npc: "", prereq: "" },
+        daily_marie: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- weekly ---
+        weekly_nightwave_complete: { text: "" },
+        weekly_nightwave_spend: { text: "" },
+        weekly_ayatan: { text: "", location: "", npc: "" },
+        weekly_clem: { text: "", location: "", npc: "", prereq: "" },
+        weekly_kahl_garrison: { text: "", location: "", npc: "", prereq: "" },
+        weekly_archon_hunt: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_duviri_circuit_sp: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_search_pulses: { text: "" },
+        weekly_netracells: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eda: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_eta: { text: "", location: "", npc: "", prereq: "", info: "" },
+        weekly_calendar: { text: "", location: "", terminal: "", prereq: "" },
+        weekly_invigorations: { text: "", location: "", npc: "", prereq: "" },
+        weekly_descendia: { text: "", location: "", terminal: "" },
+        weekly_descendia_sp: { text: "", location: "", terminal: "" },
+        weekly_vendors: { text: "" },
+        weekly_iron_wake: { text: "", location: "", npc: "", prereq: "" },
+        weekly_yonta: { text: "", location: "", npc: "", prereq: "" },
+        weekly_acrithis: { text: "", location: "", npc: "", prereq: "" },
+        weekly_teshin: { text: "", location: "", npc: "", prereq: "" },
+        weekly_bird3: { text: "", location: "", npc: "", prereq: "" },
+        weekly_nightcap: { text: "", location: "", npc: "", prereq: "" },
+        weekly_zorba: { text: "", location: "", npc: "", prereq: "" },
+
+        // --- other ---
+        other_baro: { text: "", location: "", npc: "" },
+        other_grandmother_tokens: { text: "", location: "", prereq: "" },
+        other_yonta_voidplumes: { text: "", location: "", npc: "", prereq: "" },
+        other_loid_voca: { text: "", location: "", npc: "", prereq: "" },
+        other_glast: { text: "", location: "", npc: "", prereq: "" },
+        other_eleanor: { text: "", location: "", npc: "", prereq: "" },
+    },
+
+    cycles: {
+        // column names
+        "Item": "",
+        "Tileset": "",
+        "Boss": "",
+        "Season": "",
+        "Mission": "",
+        "Price": "",
+        "Location": "",
+        "Increased Spawns": "",
+        "Items": "",
+        "Coda Weapons": "",
+
+        // weekly_ayatan items
+        "Ayatan Sah Sculpture": "",
+        "Ayatan Ayr Sculpture": "",
+        "Ayatan Orta Sculpture": "",
+        "Ayatan Vaya Sculpture": "",
+        "Ayatan Piv Sculpture": "",
+        "Ayatan Valana Sculpture": "",
+
+        // weekly_ayatan tileset
+        "Orokin Derelict (Deimos)": "",
+        "Orokin Tower (Void)": "",
+
+        // weekly_kahl_garrison mission
+        "Sneaky Sabotage": "",
+        "Junk Run": "",
+        "Prison Break": "",
+
+        // weekly_kahl_garrison tileset
+        "Spaceport (Orb Vallis, Venus)": "",
+        "Grineer Forest (Earth)": "",
+        "Murex": "",
+
+        // weekly_archon_hunt items
+        "Azure Archon Shard": "",
+        "Crimson Archon Shard": "",
+        "Amber Archon Shard": "",
+
+        // weekly_archon_hunt bosses
+        "🦉 Archon Boreal": "",
+        "🐺 Archon Amar": "",
+        "🐍 Archon Nira": "",
+
+        // weekly_archon_hunt tilesets
+        "Grineer Settlement (Mars)": "",
+        "Corpus Gas City (Jupiter)": "",
+
+        // weekly_duviri_circuit items
+        "Blueprints for Excalibur, Trinity, or Ember": "",
+        "Blueprints for Loki, Mag, or Rhino": "",
+        "Blueprints for Ash, Frost, or Nyx": "",
+        "Blueprints for Saryn, Vauban, or Nova": "",
+        "Blueprints for Nekros, Valkyr, or Oberon": "",
+        "Blueprints for Hydroid, Mirage, or Limbo": "",
+        "Blueprints for Mesa, Chroma, or Atlas": "",
+        "Blueprints for Ivara, Inaros, or Titania": "",
+        "Blueprints for Nidus, Octavia, or Harrow": "",
+        "Blueprints for Gara, Khora, or Revenant": "",
+        "Blueprints for Garuda, Baruuk, or Hildryn": "",
+
+        // weekly_duviri_circuit_sp items
+        "Incarnon Adapters for Braton, Kunai, Lato, Paris, and Skana": "",
+        "Incarnon Adapters for Angstrum, Anku, Boar, Gammacor, and Gorgon": "",
+        "Incarnon Adapters for Bo, Furax, Furis, Latron, and Strun": "",
+        "Incarnon Adapters for Boltor, Bronco, Ceramic Dagger, Lex, and Magistar": "",
+        "Incarnon Adapters for Atomos, Dual Ichor, Dual Toxocyst, Miter, and Torid": "",
+        "Incarnon Adapters for Ack & Brunt, Burston, Nami Solo, Soma, and Vasto": "",
+        "Incarnon Adapters for Despair, Dread, Hate, Sibear, and Zylok": "",
+        "Incarnon Adapters for Cestra, Dera, Okina, Sicarus, and Sybaris": "",
+
+        // weekly_calendar seasons
+        "Winter": "",
+        "Spring": "",
+        "Summer": "",
+        "Autumn": "",
+
+        // weekly_calendar increased spawns (keep emoji, translate eximus type)
+        "❄️ Arctic Eximus": "",
+        "🟢 Jade Light Eximus": "",
+        "🔥 Arson Eximus": "",
+        "🧲 Energy Leech Eximus": "",
+
+        // weekly_teshin items
+        "Umbra Forma Blueprint": "",
+        "50,000 Kuva": "",
+        "Kitgun Riven Mod": "",
+        "3x Built Forma": "",
+        "Zaw Riven Mod": "",
+        "30,000 Endo": "",
+        "Rifle Riven Mod": "",
+        "Shotgun Riven Mod": "",
+
+        // other_baro locations
+        "Strata Relay, Earth": "",
+        "Larunda Relay, Mercury": "",
+        "Kronia Relay, Saturn": "",
+        "Orcus Relay, Pluto (MR 8+)": "",
+
+        // other_eleanor coda weapons
+        "Hema, Sporothrix, Catabolyst, Pox, Dual Torxica, Mire, and Motovore": "",
+        "Bassocyst, Bubonico, Synapse, Tysis, Caustacyst, Hirudo, and Pathocyst": "",
+    },
+
+    moreInfo: {
+        daily_first_win_bonus: "",
+        daily_syndicate_gain: "",
+        daily_syndicate_spend: "",
+    },
+};

--- a/sources/js/tasks.json
+++ b/sources/js/tasks.json
@@ -174,7 +174,7 @@
                         },
                         {
                             "id": "daily_kim_lettie",
-                            "text": "Belladona ~{@ (Lettie)",
+                            "text": "Belladona (Lettie)",
                             "icon": "KIM/RetroPfpB.png",
                             "noIconFilter": true
                         },

--- a/sources/tests/i18n.test.js
+++ b/sources/tests/i18n.test.js
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "vitest";
+import { LOCALE_MODULES, resolveLocale } from "../js/i18n/i18n.js";
+import tasks from "../js/tasks.json" with { type: "json" };
+
+const en = LOCALE_MODULES.en;
+const enKeys = Object.keys(en.ui);
+const PH = /\{(\w+)\}/g;
+const phset = (s) => new Set(s.match(PH) || []);
+const eqSet = (a, b) => a.size === b.size && [...a].every((x) => b.has(x));
+
+// flatten task ids
+const ids = new Set();
+const walk = (t) => { ids.add(t.id); (t.subtasks || []).forEach(walk); };
+for (const s in tasks) tasks[s].forEach(walk);
+
+// every active non-English locale (auto-tracks whatever's registered in i18n.js)
+const otherLocales = Object.entries(LOCALE_MODULES).filter(([code]) => code !== "en");
+
+describe.each(otherLocales)("%s locale", (name, loc) => {
+    test("has every en ui key", () => {
+        const missing = enKeys.filter((k) => !(k in loc.ui));
+        expect(missing, `missing: ${missing.join(", ")}`).toEqual([]);
+    });
+    test("no stray/typo ui keys", () => {
+        const extra = Object.keys(loc.ui).filter((k) => !(k in en.ui));
+        expect(extra, `extra: ${extra.join(", ")}`).toEqual([]);
+    });
+    test("placeholders preserved in every ui string", () => {
+        const bad = enKeys
+            // empty string = not translated yet, so there are no placeholders to check
+            .filter((k) => k in loc.ui && loc.ui[k] !== "" && !eqSet(phset(en.ui[k]), phset(loc.ui[k])))
+            .map((k) => `${k} (en:${[...phset(en.ui[k])]} ${name}:${[...phset(loc.ui[k])]})`);
+        expect(bad, bad.join(" | ")).toEqual([]);
+    });
+    test("task overlay keys are all real task ids", () => {
+        const bogus = Object.keys(loc.tasks).filter((id) => !ids.has(id));
+        expect(bogus, `unknown ids: ${bogus.join(", ")}`).toEqual([]);
+    });
+    test("baseOfOperations.label used consistently in localized locations", () => {
+        const label = loc.ui["baseOfOperations.label"];
+        // any localized location mentioning a base must use the exact label phrase
+        const offenders = Object.entries(loc.tasks)
+            .filter(([, f]) => f.location && /base/i.test(f.location) && !f.location.includes(label))
+            .map(([id, f]) => `${id}: "${f.location}"`);
+        expect(offenders, offenders.join(" | ")).toEqual([]);
+    });
+});
+
+describe("resolveLocale (browser language → locale code)", () => {
+    test.for([
+        // exact / region tags
+        ["pt-BR", "pt-br"],
+        ["pt-PT", "pt-br"], // only Brazilian Portuguese is shipped
+        ["pt", "pt-br"],
+        ["en-US", "en"],
+        ["de-AT", "de"],
+        ["fr-CA", "fr"],
+        // Chinese script resolution from region-only tags
+        ["zh-CN", "zh-hans"],
+        ["zh-SG", "zh-hans"],
+        ["zh-TW", "zh-hant"],
+        ["zh-HK", "zh-hant"],
+        ["zh-MO", "zh-hant"],
+        ["zh-Hans", "zh-hans"],
+        ["zh-Hant", "zh-hant"],
+        ["zh", "zh-hans"], // bare Chinese defaults to Simplified
+        // no match
+        ["xx", null],
+        ["eo", null],
+    ])("%s -> %s", ([tag, expected]) => {
+        expect(resolveLocale(tag)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## New Features

* **Internationalization (i18n):** The whole app can now be shown in other languages. A new engine (`sources/js/i18n/`) handles locale detection, string lookup, and fallback, and a **language switcher** now lives in the header.
* **15 languages:** English and French are fully translated; ready-to-fill scaffolds are included for Italian, German, Spanish, Brazilian Portuguese, Russian, Polish, Ukrainian, Turkish, Japanese, Simplified Chinese, Traditional Chinese, Korean, and Thai.
* **Region-aware detection:** Browser language is matched smartly — `pt-BR` → Brazilian Portuguese, and any Chinese region (`zh-CN`, `zh-TW`, `zh-HK`, …) resolves to Simplified/Traditional via `Intl.Locale`.

## How It Works

* **English is canonical** — every other locale falls back to it, so anything untranslated still appears (in English) instead of blank.
* **Empty `""` = not translated yet**, falling back to English/source. Partial translations are safe to ship.
* **`meta.ready` gates visibility** — a language only shows in the switcher once it's marked ready (English always available), so nobody lands on an empty UI.

## Enhancements

* **"Help translate on GitHub"** link in the switcher, plus a contributor guide (`sources/js/i18n/README.md`) on how to add or finish a language.
* **Automated tests** (`sources/tests/i18n.test.js`): each locale is checked for key parity, preserved `{placeholders}`, valid task ids, and base-of-operations consistency — plus a table testing browser-tag → locale resolution.
* **Header layout:** a long translated description now wraps to a second line instead of pushing the theme/menu controls below it.
* **Disabled browser auto-translation** so tools like Google Translate don't fight the app's own live DOM updates.

## Fixes

* **DST detection for GMT±0 zones** (e.g. Europe/London): a zero UTC offset formats as the bare string `"GMT"`, which parsed to `NaN` and broke `isDst` during summer time. Caught by the test suite.
* Fixed corrupted `daily_kim_lettie` text (`Belladona ~{@ (Lettie)` → `Belladona (Lettie)`).

## Version

* Bump version to 5.1.0 in `app.js` and `package.json`.