### PR TITLE
Fix critical startup error related to Baro status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-checklist",
-  "version": "5.1",
+  "version": "5.1.1",
   "description": "A Warframe Task Checklist to track daily, weekly, and other tasks. Built with HTML, CSS, and vanilla JavaScript, processed with Vite.",
   "type": "module",
   "scripts": {

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -31,7 +31,7 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.1";
+const APP_VERSION = "5.1.1";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
 const WARFRAME_VERSION = "43.0.2";
@@ -768,7 +768,7 @@ function makeInfoLine(task, appendTo) {
             }
 
             cycleIndex = modulo(Math.floor((now.getTime() - ref.getTime()) / period), cycleCount);
-            if (!isAvailable) {cycleIndex++;}
+            if (!isAvailable) { cycleIndex = modulo(cycleIndex + 1, cycleCount); }
             console.log(`${task.id} cycleIndex ${cycleIndex}`);
             const cycleData = cycles[task.id].columns[0].order[cycleIndex];
 


### PR DESCRIPTION
There's currently an error that's causing all "Other Tasks" to not show up. This is caused by a bug in how intermittent tasks are handled when they get to the end of their cycle schedule. Currently, Baro has left Orcus (the last item on his cycle list), but has not yet arrived at Strata. This one-line change ensures the list wraps-around properly in such a case.

Live now at https://ansq.github.io/Warframe-Task-Checklist/