### PR TITLE
Improvements to hidden tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-checklist",
-  "version": "5.1",
+  "version": "5.2",
   "description": "A Warframe Task Checklist to track daily, weekly, and other tasks. Built with HTML, CSS, and vanilla JavaScript, processed with Vite.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-checklist",
-  "version": "5.2",
+  "version": "5.3",
   "description": "A Warframe Task Checklist to track daily, weekly, and other tasks. Built with HTML, CSS, and vanilla JavaScript, processed with Vite.",
   "type": "module",
   "scripts": {

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -196,7 +196,7 @@ h1 {
         font-size: 1.75rem;
     }
 }
-h2 {
+#checklist-container h2 {
     color: var(--text-header);
     cursor: pointer;
     display: flex;
@@ -210,10 +210,10 @@ h2 {
     margin-bottom: 0.25rem;
     border-bottom: 1px solid var(--border-color);
 }
-h2 > span:first-of-type {
+#checklist-container h2 > span:first-of-type {
     flex-grow: 1;
 }
-h2 .reset-time-local {
+#checklist-container h2 .reset-time-local {
     font-size: 0.75rem;
     font-weight: 400;
     color: var(--text-secondary);

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -132,6 +132,10 @@ body.light-mode {
     padding: 0;
 }
 
+:where(button) {
+    cursor: pointer;
+}
+
 /* --- Base Body Styles --- */
 body {
     font-family: 'Inter', sans-serif;

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -218,6 +218,7 @@ h1 {
     font-weight: 400;
     color: var(--text-secondary);
     margin-left: 0.5rem;
+    font-variant-numeric: tabular-nums;
 }
 .app-description {
     color: var(--text-secondary);

--- a/sources/css/critical.css
+++ b/sources/css/critical.css
@@ -242,14 +242,21 @@ h1 {
 }
 
 /* --- Collapsible Section Basics --- */
-.collapse-icon {
-    width: 1rem; height: 1rem;
-    transition: transform 0.3s ease-in-out;
+.collapse-btn {
     flex-shrink: 0;
-    margin-left: 0.5rem;
+    margin-left: 0.5em;
+    border: none;
+    display: flex;
+    align-items: center;
+    svg {
+        height: 1.25em;
+        width: 1.25em;
+        padding: 0.125em;
+        transition: transform 0.3s ease-in-out;
+    }
 }
-.section-toggle[aria-expanded="false"] .collapse-icon,
-.parent-task-header[aria-expanded="false"] .collapse-icon {
+.section-toggle[aria-expanded="false"] .collapse-btn svg,
+.parent-task-header[aria-expanded="false"] .collapse-btn svg {
     transform: rotate(-90deg);
 }
 .section-content, .subtask-collapsible {

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -23,6 +23,10 @@
     /* display: none; by default, JS will make one visible */
 }
 
+:where(label) {
+    cursor: pointer;
+}
+
 /* --- Content Box Element Styling (Non-Critical Parts) --- */
 h2:hover {
     background-color: var(--section-header-hover-bg);
@@ -219,12 +223,12 @@ input[type="checkbox"]:indeterminate::after {
     content: "\1F512\FE0E"; /* LOCK + VARIATION SELECTOR-15 (text presentation) */
     color: var(--checkbox-lock-color);
 }
-li.task-item {
+.task-item {
     display: flex;
     align-items: start;
     margin-bottom: 0.5rem;
 }
-li.parent-task-container {
+.parent-task-container {
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -296,7 +300,8 @@ li.parent-task-container {
     opacity: 1;
     color: var(--menu-close-btn-hover-color);
 }
-#options-menu .menu-btn {
+#options-menu :is(.menu-btn, .menu-item) {
+    font-weight: 600;
     display: block;
     width: 100%;
     text-align: left;
@@ -304,8 +309,12 @@ li.parent-task-container {
     margin-right: 0;
     margin-bottom: 0.75rem;
 }
-#options-menu .menu-btn:last-child {
+#options-menu :is(.menu-btn, .menu-item):last-child {
     margin-bottom: 0;
+}
+#options-menu .checkbox-option {
+    display: flex;
+    align-items: start;
 }
 
 /* Dialogs */
@@ -316,6 +325,12 @@ dialog {
 dialog::backdrop {
     background-color: var(--backdrop-color);
     backdrop-filter: var(--backdrop-filter);
+}
+
+dialog hr {
+    border: none;
+    border-top: 1px solid var(--menu-panel-border);
+    margin: 1rem 0;
 }
 
 @media (prefers-reduced-motion: no-preference) {
@@ -377,8 +392,9 @@ body:not(.light-mode) img.icon-filter {
     margin: 0;
 }
 
-/* Collapsible Extra Task Info */
-.task-info-expander {
+/* Collapsible Stuff */
+.task-info-expander,
+.task-autohide-expander {
     display: grid;
     grid-template-rows: 1fr;
     overflow: hidden;
@@ -389,7 +405,8 @@ body:not(.light-mode) img.icon-filter {
 .task-item .checked .task-info-expander {
     grid-template-rows: 0fr;
 }
-.task-info-expander > div {
+.task-info-expander > div,
+.task-autohide-expander > div {
     min-height: 0;
 }
 
@@ -522,4 +539,46 @@ body:not(.light-mode) img.icon-filter {
 .tooltip {
     text-decoration: underline dotted;
     cursor: pointer;
+}
+
+/* Hide completed tasks */
+body.hide-completed-tasks .task-autohide-expander:has(> .task-item > .checked),
+body.hide-completed-tasks .task-autohide-expander:has(> .parent-task-container > .parent-task-header > .checked) {
+    grid-template-rows: 0fr;
+    @media (prefers-reduced-motion: no-preference) {
+        transition: grid-template-rows 200ms 5s;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        transition: grid-template-rows 0s 5s;
+    }
+
+    &::after {
+        background-color: color(from var(--checkbox-checked-bg) srgb r g b / 0.25);
+        width: 0;
+    }
+}
+body.hide-completed-tasks .task-autohide-expander > .task-item:has(> .checked) {
+    margin: 0;
+    @media (prefers-reduced-motion: no-preference) {
+        transition: margin 200ms 5s;
+    }
+    @media (prefers-reduced-motion: reduce) {
+        transition: margin 0s 5s;
+    }
+}
+/* countdown bar */
+.task-autohide-expander {
+    position: relative;
+}
+.task-autohide-expander::after {
+    position: absolute;
+    top: 0.125rem;
+    left: 1.75rem;
+    width: 100%;
+    height: 0.25rem;
+    border-radius: 0.125rem;
+    background-color: transparent;
+    content: "";
+    z-index: -1;
+    transition: width 5s linear;
 }

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -135,7 +135,7 @@ a.git-hash-text {
 .task-title {
     font-weight: 600;
 }
-.hide-task-btn, .notification-toggle-btn {
+.task-ctrl-btn {
     background: none;
     border: none;
     color: var(--text-muted);
@@ -148,11 +148,13 @@ a.git-hash-text {
     justify-content: center;
     flex-shrink: 0;
 }
-.hide-task-btn svg, .notification-toggle-btn svg {
+.task-ctrl-btn svg {
     width: 1rem;
     height: 1rem;
 }
-.hide-task-btn:hover, .notification-toggle-btn:hover { opacity: 1; }
+.task-ctrl-btn:hover {
+    opacity: 1;
+}
 .notification-toggle-btn.active {
     color: var(--notification-btn-active-color);
     opacity: 1;

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -135,9 +135,6 @@ a.git-hash-text {
 .task-title {
     font-weight: 600;
 }
-.task-item.hidden-task {
-    display: none !important;
-}
 .hide-task-btn, .notification-toggle-btn {
     background: none;
     border: none;
@@ -398,7 +395,7 @@ body:not(.light-mode) img.icon-filter {
 
 /* Collapsible Stuff */
 .task-info-expander,
-.task-autohide-expander {
+.task-expander {
     display: grid;
     grid-template-rows: 1fr;
     overflow: hidden;
@@ -410,7 +407,7 @@ body:not(.light-mode) img.icon-filter {
     grid-template-rows: 0fr;
 }
 .task-info-expander > div,
-.task-autohide-expander > div {
+.task-expander > div {
     min-height: 0;
 }
 
@@ -545,9 +542,23 @@ body:not(.light-mode) img.icon-filter {
     cursor: pointer;
 }
 
+/* Hidden task animation */
+.task-expander:has(> .task-item.hidden-task) {
+    grid-template-rows: 0fr;
+    @media (prefers-reduced-motion: no-preference) {
+        transition: grid-template-rows 200ms;
+    }
+}
+.task-expander > .task-item.hidden-task {
+    margin: 0;
+    @media (prefers-reduced-motion: no-preference) {
+        transition: margin 200ms;
+    }
+}
+
 /* Hide completed tasks */
-body.hide-completed-tasks .task-autohide-expander:has(> .task-item > .checked),
-body.hide-completed-tasks .task-autohide-expander:has(> .parent-task-container > .parent-task-header > .checked) {
+body.hide-completed-tasks .task-expander:has(> .task-item > .checked),
+body.hide-completed-tasks .task-expander:has(> .parent-task-container > .parent-task-header > .checked) {
     grid-template-rows: 0fr;
     @media (prefers-reduced-motion: no-preference) {
         transition: grid-template-rows 200ms 5s;
@@ -561,7 +572,7 @@ body.hide-completed-tasks .task-autohide-expander:has(> .parent-task-container >
         width: 0;
     }
 }
-body.hide-completed-tasks .task-autohide-expander > .task-item:has(> .checked) {
+body.hide-completed-tasks .task-expander > .task-item:has(> .checked) {
     margin: 0;
     @media (prefers-reduced-motion: no-preference) {
         transition: margin 200ms 5s;
@@ -571,10 +582,10 @@ body.hide-completed-tasks .task-autohide-expander > .task-item:has(> .checked) {
     }
 }
 /* countdown bar */
-.task-autohide-expander {
+.task-expander {
     position: relative;
 }
-.task-autohide-expander::after {
+.task-expander::after {
     position: absolute;
     top: 0.125rem;
     left: 1.75rem;
@@ -585,4 +596,32 @@ body.hide-completed-tasks .task-autohide-expander > .task-item:has(> .checked) {
     content: "";
     z-index: -1;
     transition: width 5s linear;
+}
+
+/* List stats */
+.list-stats {
+    color: var(--text-secondary);
+    font-size: 85%;
+    display: grid;
+    grid-template-rows: 0fr;
+}
+.list-stats > div {
+    overflow: hidden;
+}
+body.hide-completed-tasks .list-stats:has(> div > span[data-count]:not([data-count="0"])), /* with autohide, show when any stat is nonzero */
+body:not(.hide-completed-tasks) .list-stats:has(> div > span:not(.stats-completed)[data-count]:not([data-count="0"])) /* without autohide, show when any stat except completed is nonzero */ {
+    grid-template-rows: 1fr;
+}
+@media (prefers-reduced-motion: no-preference) {
+    .list-stats { transition: grid-template-rows 200ms; }
+}
+.list-stats > div {
+    margin-bottom: 0.5em;
+}
+.list-stats > div > span[data-count="0"], /* hide stat when equal to 0 */
+body:not(.hide-completed-tasks) .list-stats .stats-completed /* hide completed when autohide is off */ {
+    display: none;
+}
+.list-stats > div > span:has(~ span[data-count]:not([data-count="0"]))::after { /* spacer after stat if it has another nonzero stat after it */
+    content: " | ";
 }

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -132,6 +132,9 @@ a.git-hash-text {
 .task-description.unavailable .task-text {
     font-style: italic;
 }
+.task-title {
+    font-weight: 600;
+}
 .task-item.hidden-task {
     display: none !important;
 }
@@ -183,6 +186,7 @@ a.git-hash-text {
     color: var(--baro-timer-color);
     margin-left: 0.4rem;
     display: inline-block;
+    font-variant-numeric: tabular-nums;
 }
 
 

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -648,6 +648,40 @@ body:not(.hide-completed-tasks) .list-stats .stats-completed /* hide completed w
     }
 }
 
+.incomplete-count {
+    font-size: 65%;
+    font-weight: 600;
+    background-color: var(--text-header);
+    color: var(--bg-content);
+    border-radius: 1em;
+    display: grid;
+    padding: 0;
+    margin: 0;
+    grid-template-columns: 0fr;
+    transform: scale(0, 0);
+    opacity: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    & > div {
+        min-width: 0;
+    }
+    .parent-task-header[aria-expanded="false"] & {
+        grid-template-columns: 1fr;
+        transform: scale(1, 1);
+        opacity: 1;
+        padding: 0 0.4em;
+        margin-left: 0.25em;
+    }
+    @media (prefers-reduced-motion: no-preference) {
+        transition:
+            grid-template-columns 0.2s ease,
+            transform 0.2s ease,
+            opacity 0.2s ease,
+            padding 0.2s ease,
+            margin 0.2s ease;
+    }
+}
+
 #hidden-tasklist {
     ul {
         list-style: none;

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -665,7 +665,7 @@ body:not(.hide-completed-tasks) .list-stats .stats-completed /* hide completed w
     & > div {
         min-width: 0;
     }
-    .parent-task-header[aria-expanded="false"] & {
+    .parent-task-header[aria-expanded="false"] &:not([data-count="0"]) {
         grid-template-columns: 1fr;
         transform: scale(1, 1);
         opacity: 1;

--- a/sources/css/style.css
+++ b/sources/css/style.css
@@ -28,7 +28,7 @@
 }
 
 /* --- Content Box Element Styling (Non-Critical Parts) --- */
-h2:hover {
+#checklist-container h2:hover {
     background-color: var(--section-header-hover-bg);
 }
 .task-description { color: var(--text-label); }
@@ -192,12 +192,12 @@ a.git-hash-text {
 /* --- Interactive Elements (Using Variables) --- */
 input[type="checkbox"] {
     appearance: none; -webkit-appearance: none; -moz-appearance: none;
-    width: 1.25rem; height: 1.25rem;
-    margin: 0.125rem 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    margin: 0.125rem 0.5rem 0.125rem 0;
     border: 2px solid var(--checkbox-border);
     border-radius: 0.25rem; cursor: pointer;
     position: relative;
-    margin-right: 0.5rem;
     transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
     background-color: var(--checkbox-bg);
     flex-shrink: 0;
@@ -547,13 +547,15 @@ body:not(.light-mode) img.icon-filter {
 /* Hidden task animation */
 .task-expander:has(> .task-item.hidden-task) {
     grid-template-rows: 0fr;
-    @media (prefers-reduced-motion: no-preference) {
-        transition: grid-template-rows 200ms;
-    }
 }
 .task-expander > .task-item.hidden-task {
     margin: 0;
-    @media (prefers-reduced-motion: no-preference) {
+}
+@media (prefers-reduced-motion: no-preference) {
+    .task-expander {
+        transition: grid-template-rows 200ms;
+    }
+    .task-expander > .task-item {
         transition: margin 200ms;
     }
 }
@@ -609,9 +611,10 @@ body.hide-completed-tasks .task-expander > .task-item:has(> .checked) {
 }
 .list-stats > div {
     overflow: hidden;
+    display: flex;
 }
-body.hide-completed-tasks .list-stats:has(> div > span[data-count]:not([data-count="0"])), /* with autohide, show when any stat is nonzero */
-body:not(.hide-completed-tasks) .list-stats:has(> div > span:not(.stats-completed)[data-count]:not([data-count="0"])) /* without autohide, show when any stat except completed is nonzero */ {
+body.hide-completed-tasks .list-stats:has(> div > button[data-count]:not([data-count="0"])), /* with autohide, show when any stat is nonzero */
+body:not(.hide-completed-tasks) .list-stats:has(> div > button:not(.stats-completed)[data-count]:not([data-count="0"])) /* without autohide, show when any stat except completed is nonzero */ {
     grid-template-rows: 1fr;
 }
 @media (prefers-reduced-motion: no-preference) {
@@ -620,10 +623,51 @@ body:not(.hide-completed-tasks) .list-stats:has(> div > span:not(.stats-complete
 .list-stats > div {
     margin-bottom: 0.5em;
 }
-.list-stats > div > span[data-count="0"], /* hide stat when equal to 0 */
+.list-stats > div > button[data-count="0"], /* hide stat when equal to 0 */
 body:not(.hide-completed-tasks) .list-stats .stats-completed /* hide completed when autohide is off */ {
     display: none;
 }
-.list-stats > div > span:has(~ span[data-count]:not([data-count="0"]))::after { /* spacer after stat if it has another nonzero stat after it */
-    content: " | ";
+.list-stats button {
+    border: 1px solid var(--theme-toggle-border);
+    border-radius: 0.375rem;
+    padding: 0 0.375em;
+    margin-right: 1em;
+    display: flex;
+    align-items: center;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    &:hover {
+        background-color: var(--theme-toggle-hover-bg);
+        border-color: var(--theme-toggle-hover-border);
+        color: var(--text-label);
+    }
+    svg {
+        margin-bottom: 0.1em;
+        margin-right: 0.25em;
+        width: 1em;
+        height: 1em;
+    }
+}
+
+#hidden-tasklist {
+    ul {
+        list-style: none;
+        padding: 0;
+    }
+    ul button {
+        width: 1.25rem;
+        height: 1.25rem;
+        margin: 0.125rem 0.5rem 0.125rem 0;
+        border: 0;
+        color: var(--text-muted);
+        transition: color 0.2s ease;
+        &:hover {
+            color: var(--text-secondary);
+        }
+    }
+    .task-title {
+        cursor: default;
+    }
+    ul.skipped button svg {
+        transform: scale(-1, 1);
+    }
 }

--- a/sources/index.html
+++ b/sources/index.html
@@ -151,6 +151,11 @@
                 <h2 class="menu-title">Options</h2>
                 <button class="menu-close-button" aria-label="Close menu">&times;</button>
             </header>
+            <div class="menu-item checkbox-option">
+                <input id="hide-completed" type="checkbox">
+                <label for="hide-completed">Hide completed tasks</label>
+            </div>
+            <hr>
             <button id="reset-daily-button" class="menu-btn">Reset Daily Checks</button>
             <button id="reset-weekly-button" class="menu-btn">Reset Weekly Checks</button>
             <button id="reset-button" class="menu-btn">Reset All Checks</button>

--- a/sources/index.html
+++ b/sources/index.html
@@ -76,9 +76,11 @@
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="daily-tasks-content">
                     <span>Daily Tasks <span class="reset-time-local" id="daily-reset-local-time">(Resets ...)</span></span>
                     <button class="hide-section-button" data-section-id="daily-tasks-section">Hide Section</button>
-                    <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                    </svg>
+                    <button class="collapse-btn" type="button">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                        </svg>
+                    </button>
                 </h2>
                 <div id="daily-tasks-content" class="section-content">
                     <ul></ul>
@@ -89,9 +91,11 @@
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="weekly-tasks-content">
                     <span>Weekly Tasks <span class="reset-time-local" id="weekly-reset-local-time">(Resets ...)</span></span>
                     <button class="hide-section-button" data-section-id="weekly-tasks-section">Hide Section</button>
-                    <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                    </svg>
+                    <button class="collapse-btn" type="button">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                        </svg>
+                    </button>
                 </h2>
                 <div id="weekly-tasks-content" class="section-content">
                     <ul></ul>
@@ -102,9 +106,11 @@
                 <h2 class="section-toggle" aria-expanded="true" aria-controls="other-tasks-content">
                     <span>Other Tasks</span>
                     <button class="hide-section-button" data-section-id="other-tasks-section">Hide Section</button>
-                    <svg class="collapse-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                    </svg>
+                    <button class="collapse-btn" type="button">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                        </svg>
+                    </button>
                 </h2>
                 <div id="other-tasks-content" class="section-content">
                     <ul></ul>

--- a/sources/index.html
+++ b/sources/index.html
@@ -166,7 +166,7 @@
     <dialog id="cycle-schedule">
         <div>
             <header class="menu-header">
-                <h2 class="menu-title"><img class="task-icon" />Schedule for <span class="title">X</span></h2>
+                <h2 class="menu-title"><img class="task-icon" />Schedule for <span class="task-title">X</span></h2>
                 <button class="menu-close-button" aria-label="Close schedule">&times;</button>
             </header>
             <table>
@@ -179,10 +179,20 @@
     <dialog id="more-info">
         <div>
             <header class="menu-header">
-                <h2 class="menu-title"><img class="task-icon" /><span class="title">X</span></h2>
+                <h2 class="menu-title"><img class="task-icon" /><span class="task-title">X</span></h2>
                 <button class="menu-close-button" aria-label="Close schedule">&times;</button>
             </header>
             <div id="more-info-content"></div>
+        </div>
+    </dialog>
+
+    <dialog id="hidden-tasklist">
+        <div>
+            <header class="menu-header">
+                <h2 class="menu-title"><img class="task-icon" /><span></span><span class="task-title"></span><span></span></h2>
+                <button class="menu-close-button" aria-label="Close menu">&times;</button>
+            </header>
+            <ul></ul>
         </div>
     </dialog>
 

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -31,10 +31,10 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.1";
+const APP_VERSION = "5.2";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
-const WARFRAME_VERSION = "43.0.2";
+const WARFRAME_VERSION = "43.0.3";
 const THEME_STORAGE_KEY = 'warframeChecklistTheme';
 
 // only update DATA_STORAGE_KEY when the data storage format changes
@@ -66,7 +66,8 @@ _prepTasks();
 let bodyElement, themeToggleButton, hamburgerButton, optionsMenu, resetDailyButton, resetWeeklyButton, resetButton,
     unhideTasksButton, lastSavedTimestampElement, saveStatusElement, sectionToggles, dailyResetTimeElement,
     weeklyResetTimeElement, errorDisplayElement, errorMessageElement, errorCloseButton, errorCopyButton,
-    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, backgroundDivs = [];
+    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, backgroundDivs,
+    hideCompletedToggle = [];
 
 
 // --- State Variables ---
@@ -86,7 +87,8 @@ let checklistData = {
     manuallyHiddenSections: {},
     lastTaskResetTimes: {},
     notificationPreferences: {},
-    notificationsSent: {}
+    notificationsSent: {},
+    hideCompletedTasks: false
 };
 
 let currentTheme = 'dark';
@@ -118,6 +120,7 @@ function initializeDOMElements() {
     wfVersionElement = document.querySelector('.warframe-version-text');
     scheduleDialog = document.getElementById("cycle-schedule");
     moreInfoDialog = document.getElementById("more-info");
+    hideCompletedToggle = document.getElementById("hide-completed");
 
     backgroundDivs = [];
     dailyBackgroundImageIds.forEach((id) => {
@@ -426,10 +429,13 @@ function showNotification(title, body) {
 function createChecklistItem(task, isChecked, isSubtask = false) {
     const isAvailable = calcTaskTimes(task, new Date()).isAvailable;
 
-    const listItem = document.createElement('li');
-    listItem.classList.add('task-item');
+    const listItem = document.createElement("li");
+    listItem.classList.add("task-autohide-expander");
+
+    const taskItem = document.createElement("div");
+    taskItem.classList.add("task-item");
     if (checklistData.hiddenTasks[task.id]) {
-        listItem.classList.add('hidden-task');
+        taskItem.classList.add("hidden-task");
     }
 
     // Checkbox
@@ -497,14 +503,14 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     hideButton.addEventListener('click', (e) => {
         e.stopPropagation();
         checklistData.hiddenTasks[task.id] = true;
-        listItem.classList.add('hidden-task');
-        updateSectionControls(listItem.closest('section').id);
+        taskItem.classList.add("hidden-task");
+        updateSectionControls(taskItem.closest("section").id);
         saveData(false);
     });
     controlsContainer.appendChild(hideButton);
 
     if (task.subtasks) {
-        listItem.classList.add('parent-task-container');
+        taskItem.classList.add("parent-task-container");
 
         const parentHeaderDiv = document.createElement('div');
         parentHeaderDiv.classList.add('parent-task-header');
@@ -533,7 +539,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
         parentHeaderDiv.appendChild(controlsContainer);
         parentHeaderDiv.appendChild(collapseIcon);
-        listItem.appendChild(parentHeaderDiv);
+        taskItem.appendChild(parentHeaderDiv);
 
         // Subtasks
         const subtaskCollapsible = document.createElement("div");
@@ -550,7 +556,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
             });
         }
         subtaskCollapsible.appendChild(subtaskList)
-        listItem.appendChild(subtaskCollapsible);
+        taskItem.appendChild(subtaskCollapsible);
 
         // On Click -> Collapse/Expand
         parentHeaderDiv.addEventListener('click', (e) => {
@@ -613,10 +619,10 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         // Info Line & Cycle Schedule
         makeInfoLine(task, label);
 
-        listItem.appendChild(checkbox);
-        if (task.icon) { listItem.appendChild(icon); }
-        listItem.appendChild(label);
-        listItem.appendChild(controlsContainer);
+        taskItem.appendChild(checkbox);
+        if (task.icon) { taskItem.appendChild(icon); }
+        taskItem.appendChild(label);
+        taskItem.appendChild(controlsContainer);
 
         // Checkbox Changed
         checkbox.addEventListener("change", (event) => {
@@ -653,6 +659,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
             saveData();
         });
     }
+    listItem.appendChild(taskItem);
     return listItem;
 }
 
@@ -1079,11 +1086,12 @@ function loadData() {
                 checklistData.lastTaskResetTimes = parsedData.lastTaskResetTimes || {};
                 checklistData.notificationPreferences = parsedData.notificationPreferences || {};
                 checklistData.notificationsSent = parsedData.notificationsSent || {};
+                checklistData.hideCompletedTasks = parsedData.hideCompletedTasks || false;
             } else { console.warn("Invalid data format found in localStorage. Starting fresh."); }
         } catch (e) {
             console.error("Error parsing saved data:", e);
             displayError("Failed to load saved progress. Data might be corrupted.");
-            checklistData = { progress: {}, lastSaved: null, lastDailyReset: null, lastWeeklyReset: null, hiddenTasks: {}, manuallyHiddenSections: {}, lastTaskResetTimes: {}, notificationPreferences: {}, notificationsSent: {} };
+            checklistData = { progress: {}, lastSaved: null, lastDailyReset: null, lastWeeklyReset: null, hiddenTasks: {}, manuallyHiddenSections: {}, lastTaskResetTimes: {}, notificationPreferences: {}, notificationsSent: {}, hideCompletedTasks: false };
         }
     }
 }
@@ -1111,6 +1119,17 @@ export function loadAndInitializeApp() {
 
     if (wfVersionElement) { wfVersionElement.textContent = `Warframe Version ${WARFRAME_VERSION}`; }
     else { console.error("Warframe version element not found!"); }
+
+    if (hideCompletedToggle) {
+        hideCompletedToggle.addEventListener("change", (event) => {
+            bodyElement.classList.toggle("hide-completed-tasks", event.target.checked);
+            checklistData.hideCompletedTasks = event.target.checked;
+            saveData();
+        });
+        hideCompletedToggle.checked = checklistData.hideCompletedTasks;
+        bodyElement.classList.toggle("hide-completed-tasks", checklistData.hideCompletedTasks);
+    }
+    else { console.error("Hide Completed Toggle not found!"); }
 
     if (resetDailyButton) { resetDailyButton.addEventListener('click', () => handleResetConfirmation(resetDailyButton, 'daily', 'Reset Daily Checks', resetDailyAction)); }
     else { console.error("Reset Daily button element not found!"); }

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -558,12 +558,14 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         parentHeaderDiv.appendChild(taskDescription);
 
         // Collapse Button
-        const collapseIcon = document.createElement("div");
-        collapseIcon.setAttribute('class', 'collapse-icon');
-        collapseIcon.innerHTML = svgIcons.collapseIcon;
+        const collapseButton = document.createElement("button");
+        collapseButton.type = "button";
+        collapseButton.classList.add("collapse-btn");
+        collapseButton.innerHTML = svgIcons.collapseIcon;
+        collapseButton.innerHTML += '<div class="incomplete-count"><div>X</div></div>';
 
         parentHeaderDiv.appendChild(controlsContainer);
-        parentHeaderDiv.appendChild(collapseIcon);
+        parentHeaderDiv.appendChild(collapseButton);
         taskItem.appendChild(parentHeaderDiv);
 
         // Subtasks
@@ -586,13 +588,15 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         subtaskCollapsible.appendChild(subtaskList)
         taskItem.appendChild(subtaskCollapsible);
 
+        updateIncompleteSubtaskCount(task, taskItem);
+
         // On Click -> Collapse/Expand
         parentHeaderDiv.addEventListener("click", (e) => {
-            if (e.target !== checkbox && !checkbox.contains(e.target) && !controlsContainer.contains(e.target) && !collapseIcon.contains(e.target) ) {
+            if (e.target !== checkbox && !checkbox.contains(e.target) && !controlsContainer.contains(e.target) && !collapseButton.contains(e.target) ) {
                 toggleCollapseSubtasks(task);
             }
         });
-        collapseIcon.addEventListener("click", (e) => {
+        collapseButton.addEventListener("click", (e) => {
             e.stopPropagation();
             toggleCollapseSubtasks(task);
         });
@@ -638,6 +642,7 @@ function checkboxChangeAction(task) {
                 // allow for nested subtasks of arbitrary depth)
                 subCheckbox.dispatchEvent(new CustomEvent("change", {detail: currentlyChecked}));
             });
+            updateIncompleteSubtaskCount(task);
         } else {
             // Update parent task checkboxes and stats
             updateParentCheckboxes(task);
@@ -693,6 +698,16 @@ function toggleCollapseSubtasks(task) {
     parentHeaderDiv.parentNode.querySelector(".subtask-collapsible").classList.toggle("collapsed", !startedCollapsed);
     checklistData.collapsedParentTasks[task.id] = !startedCollapsed;
     saveData();
+    updateIncompleteSubtaskCount(task);
+}
+
+function updateIncompleteSubtaskCount(task, queryFrom=document) {
+    if (task.subtasks) {
+        const element = queryFrom.querySelector(`#${task.id} ~ .collapse-btn .incomplete-count > div`);
+        const unchecked = queryFrom.querySelectorAll(`input[data-parent-id="${task.id}"]:not(:checked, :indeterminate, .hidden-task *)`)
+        element.innerText = unchecked.length;
+        element.parentElement.title = `${unchecked.length} incomplete subtasks of ${task.title}`;
+    }
 }
 
 function taskDialogHeaderSetup(task, dialog) {

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -467,7 +467,8 @@ function showNotification(title, body) {
     }
 }
 
-function createChecklistItem(task, isChecked, isSubtask = false) {
+function createChecklistItem(task) {
+    const isChecked = checklistData.progress[task.id] || false;
     const isAvailable = calcTaskTimes(task, new Date()).isAvailable;
 
     const listItem = document.createElement("li");
@@ -480,14 +481,14 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     }
 
     // Checkbox
-    const checkbox = document.createElement('input');
-    checkbox.type = 'checkbox';
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
     checkbox.id = task.id;
     checkbox.checked = isChecked;
     if (!isAvailable) {
         checkbox.indeterminate = true;
     }
-    if (isSubtask) {
+    if (task.parentId) {
         checkbox.dataset.parentId = task.parentId;
     }
 
@@ -534,7 +535,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     makeInfoLine(task, taskDescription);
 
     // Hide/Notif Controls
-    const controlsContainer = document.createElement('div');
+    const controlsContainer = document.createElement("div");
 
     // Notif Button
     if (task.id.startsWith("other_")) {
@@ -617,9 +618,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         subtaskList.classList.add("subtask-list");
 
         task.subtasks.forEach((subtask) => {
-            const subtaskIsChecked = checklistData.progress[subtask.id] || false;
-            const subtaskItem = createChecklistItem(subtask, subtaskIsChecked, true);
-            subtaskList.appendChild(subtaskItem);
+            subtaskList.appendChild(createChecklistItem(subtask));
         });
         subtaskList.appendChild(makeSectionStats(task.id));
         calcSectionStats(task.id, subtaskList);
@@ -717,8 +716,8 @@ function updateParentCheckboxes(task) {
             checklistData.progress[parentTaskDefinition.id] = allSubtasksDone;
 
             const parentCheckbox = document.getElementById(parentTaskDefinition.id);
-            const parentContainer = parentCheckbox ? parentCheckbox.closest(".parent-task-container") : null;
-            const parentDescription = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
+            const parentContainer = parentCheckbox?.closest(".parent-task-container");
+            const parentDescription = parentContainer?.querySelector(".parent-task-header .task-description");
 
             if (parentCheckbox) { parentCheckbox.checked = allSubtasksDone; }
             if (parentDescription) { parentDescription.classList.toggle("checked", allSubtasksDone); }
@@ -745,6 +744,7 @@ function updateIncompleteSubtaskCount(task, queryFrom=document) {
         const element = queryFrom.querySelector(`#${task.id} ~ .collapse-btn .incomplete-count > div`);
         const unchecked = queryFrom.querySelectorAll(`input[data-parent-id="${task.id}"]:not(:checked, :indeterminate, .hidden-task *)`)
         element.innerText = unchecked.length;
+        element.parentElement.dataset.count = unchecked.length;
         element.parentElement.title = `${unchecked.length} incomplete subtasks of ${task.title}`;
     }
 }
@@ -888,11 +888,11 @@ function makeInfoLine(task, appendTo) {
         // Info Line
         if (hasInfoLine) {
             if (task.npc && task.terminal) {console.warn(`[${task.id}] Tasks should specify only one of [npc, terminal].`);}
-            const infoLine = document.createElement('div');
-            infoLine.classList.add('info-line');
+            const infoLine = document.createElement("div");
+            infoLine.classList.add("info-line");
             let infoLineHTML = "";
             infoLineHTML += makeInfoLineItem(task, "location", "Location", svgIcons.locationIcon);
-            infoLineHTML = infoLineHTML.replace('Base of Operations', C.BASE_OF_OPERATIONS_TOOLTIP);
+            infoLineHTML = infoLineHTML.replace("Base of Operations", C.BASE_OF_OPERATIONS_TOOLTIP);
             infoLineHTML += makeInfoLineItem(task, "npc", "NPC", svgIcons.npcIcon);
             infoLineHTML += makeInfoLineItem(task, "terminal", "Terminal", svgIcons.terminalIcon);
             infoLineHTML += makeInfoLineItem(task, "prereq", "Requirements", svgIcons.prereqIcon);
@@ -920,23 +920,28 @@ function makeInfoLine(task, appendTo) {
 
 function populateSection(section) {
     const sectionElement = document.querySelector(`#${section}-tasks-content ul`);
-    const taskList = tasks[section];
 
     if (!sectionElement) {
         console.error("Section element not found for population:", sectionElement);
         return;
     }
-    sectionElement.innerHTML = '';
-    taskList.forEach((task) => {
-        const isChecked = checklistData.progress[task.id] || false;
-        const listItem = createChecklistItem(task, isChecked);
-        sectionElement.appendChild(listItem);
+    sectionElement.innerHTML = "";
+    tasks[section].forEach((task) => {
+        sectionElement.appendChild(createChecklistItem(task));
     });
     sectionElement.appendChild(makeSectionStats(section));
     calcSectionStats(section);
-    if (sectionElement.parentElement && sectionElement.parentElement.id) {
-        updateSectionControls(sectionElement.parentElement.id);
-    }
+
+    let updatedParents = new Set();
+    forEachTask((task) => {
+        if (task.section === section && task.parentId && !task.subtasks && !updatedParents.has(task.parentId)) {
+            // if the task is a non-root leaf node in the current section, and the first among its siblings
+            updateParentCheckboxes(task);
+            updatedParents.add(task.parentId);
+        }
+    });
+
+    updateSectionControls(sectionElement.parentElement?.id);
 }
 
 /**

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -15,6 +15,7 @@ import {
     calcCycleNumber,
     makeInfoLineItem,
     calcTaskTimes,
+    makeSectionStats,
 } from "./functions.js";
 
 import * as C from "./constants.js";
@@ -430,7 +431,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     const isAvailable = calcTaskTimes(task, new Date()).isAvailable;
 
     const listItem = document.createElement("li");
-    listItem.classList.add("task-autohide-expander");
+    listItem.classList.add("task-expander");
 
     const taskItem = document.createElement("div");
     taskItem.classList.add("task-item");
@@ -505,6 +506,8 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         checklistData.hiddenTasks[task.id] = true;
         taskItem.classList.add("hidden-task");
         updateSectionControls(taskItem.closest("section").id);
+        if (task.parentId) { calcSectionStats(task.parentId); }
+        calcSectionStats(task.id.split("_")[0]);
         saveData(false);
     });
     controlsContainer.appendChild(hideButton);
@@ -561,6 +564,8 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
                 const subtaskItem = createChecklistItem(subtask, subtaskIsChecked, true);
                 subtaskList.appendChild(subtaskItem);
             });
+            subtaskList.appendChild(makeSectionStats(task.id));
+            calcSectionStats(task.id, subtaskList);
         }
         subtaskCollapsible.appendChild(subtaskList)
         taskItem.appendChild(subtaskCollapsible);
@@ -602,10 +607,12 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
                 // allow for nested subtasks of arbitrary depth)
                 subCheckbox.dispatchEvent(new CustomEvent("change", {detail: currentlyChecked}));
             });
+
+            calcSectionStats(task.id.split("_")[0]);
             saveData();
         });
 
-    } else {
+    } else { //no subtasks
         const label = document.createElement('label');
         label.htmlFor = task.id;
         label.classList.add("task-description");
@@ -654,25 +661,28 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
             checklistData.progress[task.id] = currentlyChecked;
             label.classList.toggle("checked", currentlyChecked);
 
-            // Update parent task checkboxes
+            // Update parent task checkboxes and stats
             let t = task;
             while (t.parentId) {  // walk up the task tree
-                let parentTaskDefinition = getTaskById(t.parentId)
+                calcSectionStats(t.parentId);
+
+                let parentTaskDefinition = getTaskById(t.parentId);
 
                 if (parentTaskDefinition && parentTaskDefinition.subtasks) {
-                    const allSubtasksChecked = parentTaskDefinition.subtasks.every((st) => checklistData.progress[st.id]);
-                    checklistData.progress[parentTaskDefinition.id] = allSubtasksChecked;
+                    const allSubtasksDone = parentTaskDefinition.subtasks.every((st) => (checklistData.progress[st.id] || checklistData.hiddenTasks[st.id]));
+                    checklistData.progress[parentTaskDefinition.id] = allSubtasksDone;
 
                     const parentCheckbox = document.getElementById(parentTaskDefinition.id);
                     const parentContainer = parentCheckbox ? parentCheckbox.closest(".parent-task-container") : null;
                     const parentTextSpan = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
 
-                    if (parentCheckbox) {parentCheckbox.checked = allSubtasksChecked;}
-                    if (parentTextSpan) {parentTextSpan.classList.toggle("checked", allSubtasksChecked);}
+                    if (parentCheckbox) { parentCheckbox.checked = allSubtasksDone; }
+                    if (parentTextSpan) { parentTextSpan.classList.toggle("checked", allSubtasksDone); }
                 }
 
                 t = parentTaskDefinition;  // move up a level
             }
+            calcSectionStats(task.id.split("_")[0]);
             saveData();
         });
     }
@@ -892,9 +902,49 @@ function populateSection(section) {
         const listItem = createChecklistItem(task, isChecked);
         sectionElement.appendChild(listItem);
     });
+    sectionElement.appendChild(makeSectionStats(section));
+    calcSectionStats(section);
     if (sectionElement.parentElement && sectionElement.parentElement.id) {
         updateSectionControls(sectionElement.parentElement.id);
     }
+}
+
+/**
+ * Update the values of the section stats.
+ *
+ * @param parent - what task list to count stats on. This can be the name of a section, or the id of a task with subtasks.
+ * @param queryFrom - DOM element to find the stats box in. Defaults to `document`. Override this if the element is not inserted into the document yet.
+ */
+function calcSectionStats(parent, queryFrom=document) {
+    console.log(`calcSectionStats(${parent})`);
+    let taskList;
+    if (parent.includes("_")) {
+        taskList = getTaskById(parent).subtasks;
+    } else {
+        taskList = tasks[parent];
+    }
+    const statsBox = queryFrom.querySelector(`#stats_${parent} > div`);
+
+    let completed = 0;
+    let hidden = 0;
+    for (const task of taskList) {
+        if (checklistData.progress[task.id]) { completed++; }
+        if (checklistData.hiddenTasks[task.id]) { hidden++; }
+    }
+
+    statsBox.innerHTML = "";
+
+    const completedBox = document.createElement("span");
+    completedBox.classList.add("stats-completed");
+    completedBox.dataset.count = completed;
+    completedBox.innerText = `+${completed} completed`;
+    statsBox.appendChild(completedBox);
+
+    const hiddenBox = document.createElement("span");
+    hiddenBox.classList.add("stats-hidden");
+    hiddenBox.dataset.count = hidden;
+    hiddenBox.innerText = `+${hidden} hidden`;
+    statsBox.appendChild(hiddenBox);
 }
 
 function resetSpecificButtonState(buttonElement, defaultText, stateKey) {
@@ -948,16 +998,8 @@ function handleResetConfirmation(buttonElement, confirmKey, defaultText, resetAc
 
 function resetAllAction() {
     checklistData.progress = {};
-    localStorage.setItem(DATA_STORAGE_KEY, JSON.stringify(checklistData));
-
-    const allCheckboxes = document.querySelectorAll('#checklist-container input[type="checkbox"]');
-    allCheckboxes.forEach((checkbox) => {
-        checkbox.checked = false;
-        const listItem = checkbox.closest('li');
-        const taskDescription = listItem.querySelector(".task-description");
-        if (taskDescription) {taskDescription.classList.remove("checked")};
-    });
-    updateLastSavedDisplay(checklistData.lastSaved);
+    saveData();
+    ["daily", "weekly", "other"].forEach(populateSection);
     console.log("Checklist reset complete.");
 }
 

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -364,7 +364,14 @@ function otherTaskReset(task) {
     const cycleNumber = calcCycleNumber(task, now);
     const lastResetTime = checklistData.lastTaskResetTimes[task.id] || 0;
     const lastResetCycleNumber = calcCycleNumber(task, lastResetTime);
-    if (cycleNumber > lastResetCycleNumber || !calcTaskTimes(task, now).isAvailable) {
+
+    if (checklistData.progress[task.id] && !calcTaskTimes(task, now).isAvailable) {
+        // Uncheck unavailable task
+        checklistData.progress[task.id] = false;
+        didReset = true;
+    }
+
+    if (cycleNumber > lastResetCycleNumber) {
         // Reset task
         if (checklistData.progress[task.id] || checklistData.skippedTasks[task.id]) {
             checklistData.progress[task.id] = false;
@@ -483,12 +490,17 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
     // Skip Button
     const skipButton = document.createElement("button");
-    let when = "this cycle";
-    if (task.id.startsWith("daily_")) { when = "today"; }
-    else if (task.id.startsWith("weekly_")) { when = "this week"; }
     skipButton.classList.add("task-ctrl-btn");
-    skipButton.setAttribute("aria-label", `Skip task ${when}: ${task.title}`);
-    skipButton.title = `Skip task ${when}: ${task.title}`;
+    let skipTooltip;
+    if (isAvailable) {
+        let when = "this cycle";
+        if (task.id.startsWith("daily_")) { when = "today"; }
+        else if (task.id.startsWith("weekly_")) { when = "this week"; }
+        skipTooltip = `Skip task ${when}: ${task.title}`;
+    } else {
+        skipTooltip = `Hide task until it becomes available: ${task.title}`;
+    }
+    skipButton.title = skipButton.ariaLabel = skipTooltip;
     skipButton.innerHTML = svgIcons.skipIcon;
     skipButton.addEventListener("click", (e) => {
         e.stopPropagation();

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -462,6 +462,37 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     // Task Icon
     const icon = makeTaskIcon(task);
 
+    // Task Description
+    const taskDescription = document.createElement(task.subtasks ? "div" : "label");
+    taskDescription.classList.add("task-description");
+    if (!tasks.subtasks) { taskDescription.htmlFor = task.id; }
+    if (isChecked) { taskDescription.classList.add("checked"); }
+    if (!isAvailable) { taskDescription.classList.add("unavailable"); }
+
+    // Task Text
+    const taskTitle = document.createElement("span");
+    taskTitle.classList.add("task-title");
+    taskTitle.innerHTML = task.title;
+    taskDescription.appendChild(taskTitle);
+    if (task.text) {
+        taskTitle.innerHTML += ": ";
+        const taskText = document.createElement("span");
+        taskText.innerHTML = task.text;
+        taskText.classList.add("task-text");
+        taskDescription.appendChild(taskText);
+    }
+
+    // Reset Timer
+    if (task.period) {
+        const resetTimer = document.createElement("span");
+        resetTimer.classList.add("other-countdown");
+        resetTimer.textContent = "(Loading...)";
+        taskDescription.appendChild(resetTimer);
+    }
+
+    // Info Line & Cycle Schedule
+    makeInfoLine(task, taskDescription);
+
     // Hide/Notif Controls
     const controlsContainer = document.createElement('div');
 
@@ -540,24 +571,6 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
         parentHeaderDiv.appendChild(checkbox);
         if (task.icon) { parentHeaderDiv.appendChild(icon); }
-
-        // Task Text & Info Line
-        const taskDescription = document.createElement("div");
-        taskDescription.classList.add("task-description");
-        const taskTitle = document.createElement("span");
-        taskTitle.classList.add("task-title");
-        taskTitle.innerHTML = task.title;
-        taskDescription.appendChild(taskTitle);
-        if (task.text) {
-            taskTitle.innerHTML += ": ";
-            const taskText = document.createElement("span");
-            taskText.innerHTML = task.text;
-            taskText.classList.add("task-text");
-            taskDescription.appendChild(taskText);
-        }
-        if (isChecked) {taskDescription.classList.add("checked");}
-        if (!isAvailable) {taskDescription.classList.add("unavailable");}
-        makeInfoLine(task, taskDescription);
         parentHeaderDiv.appendChild(taskDescription);
 
         // Collapse Button
@@ -604,18 +617,35 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         });
 
         // Checkbox Changed -> Change Subtasks Checkboxes
-        checkbox.addEventListener('change', (event) => {
-            let currentlyChecked;
-            if ("detail" in event) {
-                currentlyChecked = event.detail;
-            } else {
-                currentlyChecked = event.target.checked;
-            }
+        checkbox.addEventListener("change", checkboxChangeAction(task));
 
-            event.target.checked = currentlyChecked;
-            checklistData.progress[task.id] = currentlyChecked;
-            taskDescription.classList.toggle('checked', currentlyChecked);
+    } else { //no subtasks
+        taskItem.appendChild(checkbox);
+        if (task.icon) { taskItem.appendChild(icon); }
+        taskItem.appendChild(taskDescription);
+        taskItem.appendChild(controlsContainer);
 
+        // Checkbox Changed
+        checkbox.addEventListener("change", checkboxChangeAction(task));
+    }
+    listItem.appendChild(taskItem);
+    return listItem;
+}
+
+function checkboxChangeAction(task) {
+    return (event) => {
+        let currentlyChecked;
+        if ("detail" in event) {
+            currentlyChecked = event.detail;
+        } else {
+            currentlyChecked = event.target.checked;
+        }
+
+        event.target.checked = currentlyChecked;
+        checklistData.progress[task.id] = currentlyChecked;
+        event.target.parentNode.querySelector(".task-description").classList.toggle("checked", currentlyChecked);
+
+        if (task.subtasks) {
             task.subtasks.forEach((subtask) => {
                 if (checklistData.skippedTasks[subtask.id] || checklistData.hiddenTasks[subtask.id]) { return; }
 
@@ -627,60 +657,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
                 // allow for nested subtasks of arbitrary depth)
                 subCheckbox.dispatchEvent(new CustomEvent("change", {detail: currentlyChecked}));
             });
-
-            calcSectionStats(task.id.split("_")[0]);
-            saveData();
-        });
-
-    } else { //no subtasks
-        const label = document.createElement('label');
-        label.htmlFor = task.id;
-        label.classList.add("task-description");
-        if (isChecked) { label.classList.add("checked"); }
-        if (!isAvailable) { label.classList.add("unavailable"); }
-
-        // Task Text
-        const taskTitle = document.createElement("span");
-        taskTitle.classList.add("task-title");
-        taskTitle.innerHTML = task.title;
-        label.appendChild(taskTitle);
-        if (task.text) {
-            taskTitle.innerHTML += ": ";
-            const taskText = document.createElement("span");
-            taskText.innerHTML = task.text;
-            taskText.classList.add("task-text");
-            label.appendChild(taskText);
-        }
-
-        // Reset Timer
-        if (task.period) {
-            const resetTimer = document.createElement("span");
-            resetTimer.classList.add("other-countdown");
-            resetTimer.textContent = "(Loading...)";
-            label.appendChild(resetTimer);
-        }
-
-        // Info Line & Cycle Schedule
-        makeInfoLine(task, label);
-
-        taskItem.appendChild(checkbox);
-        if (task.icon) { taskItem.appendChild(icon); }
-        taskItem.appendChild(label);
-        taskItem.appendChild(controlsContainer);
-
-        // Checkbox Changed
-        checkbox.addEventListener("change", (event) => {
-            let currentlyChecked;
-            if ("detail" in event) {
-                currentlyChecked = event.detail;
-            } else {
-                currentlyChecked = event.target.checked;
-            }
-
-            event.target.checked = currentlyChecked;
-            checklistData.progress[task.id] = currentlyChecked;
-            label.classList.toggle("checked", currentlyChecked);
-
+        } else {
             // Update parent task checkboxes and stats
             let t = task;
             while (t.parentId) {  // walk up the task tree
@@ -702,12 +679,11 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
                 t = parentTaskDefinition;  // move up a level
             }
-            calcSectionStats(task.id.split("_")[0]);
-            saveData();
-        });
+        }
+
+        calcSectionStats(task.id.split("_")[0]);
+        saveData();
     }
-    listItem.appendChild(taskItem);
-    return listItem;
 }
 
 function taskDialogHeaderSetup(task, dialog) {

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -548,10 +548,10 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     if (task.subtasks) {
         taskItem.classList.add("parent-task-container");
 
-        const parentHeaderDiv = document.createElement('div');
-        parentHeaderDiv.classList.add('parent-task-header');
-        parentHeaderDiv.setAttribute('aria-expanded', 'true');
-        parentHeaderDiv.setAttribute('aria-controls', `${task.id}-subtasks`);
+        const parentHeaderDiv = document.createElement("div");
+        parentHeaderDiv.classList.add("parent-task-header");
+        parentHeaderDiv.ariaExpanded = !(checklistData.collapsedParentTasks[task.id] || false);
+        parentHeaderDiv.setAttribute("aria-controls", `${task.id}-subtasks`);
 
         parentHeaderDiv.appendChild(checkbox);
         if (task.icon) { parentHeaderDiv.appendChild(icon); }
@@ -569,9 +569,10 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         // Subtasks
         const subtaskCollapsible = document.createElement("div");
         subtaskCollapsible.classList.add("subtask-collapsible");
-        const subtaskList = document.createElement('ul');
+        if (checklistData.collapsedParentTasks[task.id]) { subtaskCollapsible.classList.add("collapsed"); }
+        const subtaskList = document.createElement("ul");
         subtaskList.id = `${task.id}-subtasks`;
-        subtaskList.classList.add('subtask-list');
+        subtaskList.classList.add("subtask-list");
         if (task.subtasks && Array.isArray(task.subtasks)) {
             task.subtasks.forEach((subtask) => {
                 subtask.parentId = task.id;
@@ -586,18 +587,14 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         taskItem.appendChild(subtaskCollapsible);
 
         // On Click -> Collapse/Expand
-        parentHeaderDiv.addEventListener('click', (e) => {
+        parentHeaderDiv.addEventListener("click", (e) => {
             if (e.target !== checkbox && !checkbox.contains(e.target) && !controlsContainer.contains(e.target) && !collapseIcon.contains(e.target) ) {
-                const isExpanded = parentHeaderDiv.getAttribute('aria-expanded') === 'true';
-                parentHeaderDiv.setAttribute('aria-expanded', !isExpanded);
-                subtaskCollapsible.classList.toggle('collapsed', isExpanded);
+                toggleCollapseSubtasks(task);
             }
         });
-        collapseIcon.addEventListener('click', (e) => {
+        collapseIcon.addEventListener("click", (e) => {
             e.stopPropagation();
-            const isExpanded = parentHeaderDiv.getAttribute('aria-expanded') === 'true';
-            parentHeaderDiv.setAttribute('aria-expanded', !isExpanded);
-            subtaskCollapsible.classList.toggle('collapsed', isExpanded);
+            toggleCollapseSubtasks(task);
         });
 
         // Checkbox Changed -> Change Subtasks Checkboxes
@@ -686,6 +683,15 @@ function updateParentCheckboxes(task) {
         t = parentTaskDefinition;  // move up a level
     }
     calcSectionStats(task.id.split("_")[0]);
+    saveData();
+}
+
+function toggleCollapseSubtasks(task) {
+    const parentHeaderDiv = document.getElementById(task.id).closest(".parent-task-header");
+    const startedCollapsed = (parentHeaderDiv.ariaExpanded !== "true"); // whether the section was collapsed before `toggleCollapseSubtasks` was called
+    parentHeaderDiv.ariaExpanded = startedCollapsed; // if it was collapsed before, it should now be expanded
+    parentHeaderDiv.parentNode.querySelector(".subtask-collapsible").classList.toggle("collapsed", !startedCollapsed);
+    checklistData.collapsedParentTasks[task.id] = !startedCollapsed;
     saveData();
 }
 
@@ -1236,18 +1242,12 @@ function loadData() {
     if (savedData) {
         try {
             const parsedData = JSON.parse(savedData);
-            if (parsedData && typeof parsedData === 'object') {
-                checklistData.progress = parsedData.progress || {};
-                checklistData.lastSaved = parsedData.lastSaved || null;
-                checklistData.lastDailyReset = parsedData.lastDailyReset || null;
-                checklistData.lastWeeklyReset = parsedData.lastWeeklyReset || null;
-                checklistData.hiddenTasks = parsedData.hiddenTasks || {};
-                checklistData.skippedTasks = parsedData.skippedTasks || {};
-                checklistData.manuallyHiddenSections = parsedData.manuallyHiddenSections || {};
-                checklistData.lastTaskResetTimes = parsedData.lastTaskResetTimes || {};
-                checklistData.notificationPreferences = parsedData.notificationPreferences || {};
-                checklistData.notificationsSent = parsedData.notificationsSent || {};
-                checklistData.hideCompletedTasks = parsedData.hideCompletedTasks || false;
+            if (parsedData && typeof parsedData === "object") {
+                for (const key of Object.keys(checklistData)) {
+                    if (key in parsedData) {
+                        checklistData[key] = parsedData[key];
+                    }
+                }
             } else { console.warn("Invalid data format found in localStorage. Starting fresh."); }
         } catch (e) {
             console.error("Error parsing saved data:", e);

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -34,7 +34,7 @@ const dailyBackgroundImageIds = [
 const APP_VERSION = "5.2";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
-const WARFRAME_VERSION = "43.0.3";
+const WARFRAME_VERSION = "43.0.6";
 const THEME_STORAGE_KEY = 'warframeChecklistTheme';
 
 // only update DATA_STORAGE_KEY when the data storage format changes
@@ -307,7 +307,7 @@ export function displayOtherTaskCountdown(task) {
 
             // Leaving soon notification (Arrival notification is handled in runAutoResets, the same as always available tasks)
             if (diff < C.MILLISECONDS_PER_HOUR && checklistData.notificationPreferences[task.id] && checklistData.notificationsSent[leaveNotifId] !== cycleNumber) {
-                showNotification(`${task.text.split(":")[0]} Leaving Soon!`, `Approximately ${Math.round(diff / C.MILLISECONDS_PER_MINUTE)} minutes remaining.`);
+                showNotification(`${task.title} Leaving Soon!`, `Approximately ${Math.round(diff / C.MILLISECONDS_PER_MINUTE)} minutes remaining.`);
                 checklistData.notificationsSent[leaveNotifId] = cycleNumber;
                 saveData(false);
             }
@@ -388,7 +388,7 @@ function otherTaskReset(task) {
 
         // Send and record new notification
         if (checklistData.notificationPreferences[task.id] && checklistData.notificationsSent[task.id] !== cycleNumber) {
-            showNotification(`${task.text.split(":")[0]} has reset!`, "Vendor stock may have updated.");
+            showNotification(`${task.title} has reset!`, "Vendor stock may have updated.");
             checklistData.notificationsSent[task.id] = cycleNumber;
             saveData(false);
         }
@@ -475,8 +475,8 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     if (task.id.startsWith('other_')) {
         const notificationButton = document.createElement('button');
         notificationButton.classList.add('notification-toggle-btn');
-        notificationButton.setAttribute('aria-label', `Toggle notifications for ${task.text.split(':')[0]}`);
-        notificationButton.title = `Toggle notifications for ${task.text.split(':')[0]}`;
+        notificationButton.setAttribute('aria-label', `Toggle notifications for ${task.title}`);
+        notificationButton.title = `Toggle notifications for ${task.title}`;
 
         notificationButton.innerHTML = svgIcons.bellIcon;
         if (checklistData.notificationPreferences[task.id]) { notificationButton.classList.add("active"); }
@@ -497,8 +497,8 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     // Hide Button
     const hideButton = document.createElement('button');
     hideButton.classList.add('hide-task-btn');
-    hideButton.setAttribute('aria-label', `Hide task: ${task.text.split(':')[0]}`);
-    hideButton.title = `Hide task: ${task.text.split(':')[0]}`;
+    hideButton.setAttribute('aria-label', `Hide task: ${task.title}`);
+    hideButton.title = `Hide task: ${task.title}`;
     hideButton.innerHTML = svgIcons.hideIcon;
     hideButton.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -523,12 +523,19 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         // Task Text & Info Line
         const taskDescription = document.createElement("div");
         taskDescription.classList.add("task-description");
-        const taskText = document.createElement('span');
-        taskText.textContent = task.text;
-        taskText.classList.add("task-text");
+        const taskTitle = document.createElement("span");
+        taskTitle.classList.add("task-title");
+        taskTitle.textContent = task.title;
+        taskDescription.appendChild(taskTitle);
+        if (task.text) {
+            taskTitle.textContent += ": ";
+            const taskText = document.createElement("span");
+            taskText.textContent = task.text;
+            taskText.classList.add("task-text");
+            taskDescription.appendChild(taskText);
+        }
         if (isChecked) {taskDescription.classList.add("checked");}
         if (!isAvailable) {taskDescription.classList.add("unavailable");}
-        taskDescription.appendChild(taskText);
         makeInfoLine(task, taskDescription);
         parentHeaderDiv.appendChild(taskDescription);
 
@@ -584,7 +591,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
             event.target.checked = currentlyChecked;
             checklistData.progress[task.id] = currentlyChecked;
-            taskText.classList.toggle('checked', currentlyChecked);
+            taskDescription.classList.toggle('checked', currentlyChecked);
 
             task.subtasks.forEach((subtask) => {
                 const subCheckbox = document.getElementById(subtask.id);
@@ -606,7 +613,17 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         if (!isAvailable) { label.classList.add("unavailable"); }
 
         // Task Text
-        label.innerHTML = `<span class="task-text">${task.text}</span>`;
+        const taskTitle = document.createElement("span");
+        taskTitle.classList.add("task-title");
+        taskTitle.textContent = task.title;
+        label.appendChild(taskTitle);
+        if (task.text) {
+            taskTitle.textContent += ": ";
+            const taskText = document.createElement("span");
+            taskText.textContent = task.text;
+            taskText.classList.add("task-text");
+            label.appendChild(taskText);
+        }
 
         // Reset Timer
         if (task.period) {
@@ -664,7 +681,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 }
 
 function taskDialogHeaderSetup(task, dialog) {
-    dialog.querySelector(":scope header .title").innerText = task.text.split(":")[0]; // take the task text up to the first ":" as the dialog title
+    dialog.querySelector(":scope header .title").innerText = task.title;
 
     let taskIcon = dialog.querySelector(":scope .menu-title img.task-icon");
     taskIcon.className = "task-icon"; // remove possible `icon-filter` from previous opening

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -37,7 +37,7 @@ const dailyBackgroundImageIds = [
 const APP_VERSION = "5.3";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
-const WARFRAME_VERSION = "43.0.7";
+const WARFRAME_VERSION = "43.0.8";
 const THEME_STORAGE_KEY = 'warframeChecklistTheme';
 
 // only update DATA_STORAGE_KEY when the data storage format changes
@@ -533,15 +533,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     }
     skipButton.title = skipButton.ariaLabel = skipTooltip;
     skipButton.innerHTML = svgIcons.skipIcon;
-    skipButton.addEventListener("click", (e) => {
-        e.stopPropagation();
-        checklistData.skippedTasks[task.id] = true;
-        taskItem.classList.add("hidden-task");
-        updateSectionControls(taskItem.closest("section").id);
-        if (task.parentId) { calcSectionStats(task.parentId); }
-        calcSectionStats(task.id.split("_")[0]);
-        saveData(false);
-    });
+    skipButton.addEventListener("click", hideOrSkipTaskAction(task, true));
     controlsContainer.appendChild(skipButton);
 
     // Hide Button
@@ -550,15 +542,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     hideButton.setAttribute("aria-label", `Hide task: ${task.title}`);
     hideButton.title = `Hide task: ${task.title}`;
     hideButton.innerHTML = svgIcons.hideIcon;
-    hideButton.addEventListener("click", (e) => {
-        e.stopPropagation();
-        checklistData.hiddenTasks[task.id] = true;
-        taskItem.classList.add("hidden-task");
-        updateSectionControls(taskItem.closest("section").id);
-        if (task.parentId) { calcSectionStats(task.parentId); }
-        calcSectionStats(task.id.split("_")[0]);
-        saveData(false);
-    });
+    hideButton.addEventListener("click", hideOrSkipTaskAction(task, false));
     controlsContainer.appendChild(hideButton);
 
     if (task.subtasks) {
@@ -659,31 +643,50 @@ function checkboxChangeAction(task) {
             });
         } else {
             // Update parent task checkboxes and stats
-            let t = task;
-            while (t.parentId) {  // walk up the task tree
-                calcSectionStats(t.parentId);
-
-                let parentTaskDefinition = getTaskById(t.parentId);
-
-                if (parentTaskDefinition && parentTaskDefinition.subtasks) {
-                    const allSubtasksDone = parentTaskDefinition.subtasks.every((st) => (checklistData.progress[st.id] || checklistData.hiddenTasks[st.id] || checklistData.skippedTasks[st.id]));
-                    checklistData.progress[parentTaskDefinition.id] = allSubtasksDone;
-
-                    const parentCheckbox = document.getElementById(parentTaskDefinition.id);
-                    const parentContainer = parentCheckbox ? parentCheckbox.closest(".parent-task-container") : null;
-                    const parentTextSpan = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
-
-                    if (parentCheckbox) { parentCheckbox.checked = allSubtasksDone; }
-                    if (parentTextSpan) { parentTextSpan.classList.toggle("checked", allSubtasksDone); }
-                }
-
-                t = parentTaskDefinition;  // move up a level
-            }
+            updateParentCheckboxes(task);
         }
 
         calcSectionStats(task.id.split("_")[0]);
         saveData();
     }
+}
+
+function hideOrSkipTaskAction(task, skip) {
+    return (event) => {
+        event.stopPropagation();
+        if (skip) { checklistData.skippedTasks[task.id] = true; }
+        else { checklistData.hiddenTasks[task.id] = true; }
+        const taskItem = event.target.closest(".task-item");
+        taskItem.classList.add("hidden-task");
+        updateParentCheckboxes(task);
+        updateSectionControls(taskItem.closest("section").id);
+        saveData(false);
+    }
+}
+
+function updateParentCheckboxes(task) {
+    let t = task;
+    while (t.parentId) {  // walk up the task tree
+        calcSectionStats(t.parentId);
+
+        let parentTaskDefinition = getTaskById(t.parentId);
+
+        if (parentTaskDefinition && parentTaskDefinition.subtasks) {
+            const allSubtasksDone = parentTaskDefinition.subtasks.every((st) => (checklistData.progress[st.id] || checklistData.hiddenTasks[st.id] || checklistData.skippedTasks[st.id]));
+            checklistData.progress[parentTaskDefinition.id] = allSubtasksDone;
+
+            const parentCheckbox = document.getElementById(parentTaskDefinition.id);
+            const parentContainer = parentCheckbox ? parentCheckbox.closest(".parent-task-container") : null;
+            const parentTextSpan = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
+
+            if (parentCheckbox) { parentCheckbox.checked = allSubtasksDone; }
+            if (parentTextSpan) { parentTextSpan.classList.toggle("checked", allSubtasksDone); }
+        }
+
+        t = parentTaskDefinition;  // move up a level
+    }
+    calcSectionStats(task.id.split("_")[0]);
+    saveData();
 }
 
 function taskDialogHeaderSetup(task, dialog) {
@@ -1029,6 +1032,7 @@ function hiddenTasksButtonAction(taskElement, task, stat) {
         } else {
             checklistData[C.TASKLIST_STAT_PROPERTIES[stat]][task.id] = false;
             document.getElementById(task.id).closest(".task-item").classList.remove("hidden-task");
+            updateParentCheckboxes(task);
             if (task.parentId) { calcSectionStats(task.parentId); }
             calcSectionStats(section);
         }

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -49,22 +49,6 @@ import tasks from "./tasks.json" with {type: "json"};
 import cycles from "./cycles.json" with {type: "json"};
 import moreInfo from "./moreInfo.js";
 
-function _prepTasks() {
-    function prep(period) {
-        return (task) => {
-            if (task.ref) { // alternate ref tasks need a period for countdown and reset to work correctly
-                task.period = period;
-            }
-            if (task.id in moreInfo) {
-                task.moreInfo = moreInfo[task.id];
-            }
-        }
-    }
-    tasks.daily.forEach(prep("1d"));
-    tasks.weekly.forEach(prep("7d"));
-}
-_prepTasks();
-
 // --- DOM Elements (defined after DOMContentLoaded) ---
 let bodyElement, themeToggleButton, hamburgerButton, optionsMenu, resetDailyButton, resetWeeklyButton, resetButton,
     unhideTasksButton, lastSavedTimestampElement, saveStatusElement, sectionToggles, dailyResetTimeElement,
@@ -125,6 +109,63 @@ function initializeDOMElements() {
         }
     });
 }
+
+/**
+ * For each task in the task tree, in the order they are defined, call the given
+ * `callback` function with the task definition object as a parameter.
+ */
+function forEachTask(callback) {
+    let stack = [];
+    for (const section in tasks) {
+        for (let i = 0; i < tasks[section].length; i++) {
+            // top-level tasks are not pushed in reverse order because they're immediately popped
+            stack.push(tasks[section][i]);
+            while (stack.length) {
+                const t = stack.pop();
+                callback(t); // do the thing
+                if (t.subtasks) {
+                    for (let i = t.subtasks.length - 1; i >= 0 ; i--) {
+                        // subtasks are pushed in reverse order so that they're popped in the correct order
+                        stack.push(t.subtasks[i]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+export function getTaskById(id) {
+    let task = undefined;
+    forEachTask((t) => {
+        if (t.id === id) {
+            task = t;
+        }
+    });
+    return task;
+}
+
+function prepTasks() {
+    forEachTask((task) => {
+        task.section = task.id.split("_")[0];
+
+        if (["daily", "weekly"].includes(task.section)) {
+            if (task.ref) { // alternate ref tasks need a period for countdown and reset to work correctly
+                task.period = (task.section === "daily") ? "1d" : "7d";
+            }
+        }
+
+        if (task.id in moreInfo) {
+            task.moreInfo = moreInfo[task.id];
+        }
+
+        if (task.subtasks) {
+            for (const subtask of task.subtasks) {
+                subtask.parentId = task.id;
+            }
+        }
+    });
+}
+prepTasks();
 
 function displayError(message) {
     if (!errorDisplayElement || !errorMessageElement) { return; }
@@ -347,8 +388,7 @@ function runAutoResets() {
 }
 
 function otherTaskReset(task) {
-    const section = task.id.split("_")[0];
-    if (["daily", "weekly"].includes(section) && !task.ref) { // daily and weekly tasks with an alternate ref are handled as "other" tasks
+    if (["daily", "weekly"].includes(task.section) && !task.ref) { // daily and weekly tasks with an alternate ref are handled as "other" tasks
         return false;
     } else if (!task.period) {
         console.error(`[${task.id}] other_* tasks MUST specify a "period"`);
@@ -575,16 +615,15 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         const subtaskList = document.createElement("ul");
         subtaskList.id = `${task.id}-subtasks`;
         subtaskList.classList.add("subtask-list");
-        if (task.subtasks && Array.isArray(task.subtasks)) {
-            task.subtasks.forEach((subtask) => {
-                subtask.parentId = task.id;
-                const subtaskIsChecked = checklistData.progress[subtask.id] || false;
-                const subtaskItem = createChecklistItem(subtask, subtaskIsChecked, true);
-                subtaskList.appendChild(subtaskItem);
-            });
-            subtaskList.appendChild(makeSectionStats(task.id));
-            calcSectionStats(task.id, subtaskList);
-        }
+
+        task.subtasks.forEach((subtask) => {
+            const subtaskIsChecked = checklistData.progress[subtask.id] || false;
+            const subtaskItem = createChecklistItem(subtask, subtaskIsChecked, true);
+            subtaskList.appendChild(subtaskItem);
+        });
+        subtaskList.appendChild(makeSectionStats(task.id));
+        calcSectionStats(task.id, subtaskList);
+
         subtaskCollapsible.appendChild(subtaskList)
         taskItem.appendChild(subtaskCollapsible);
 
@@ -648,7 +687,7 @@ function checkboxChangeAction(task) {
             updateParentCheckboxes(task);
         }
 
-        calcSectionStats(task.id.split("_")[0]);
+        calcSectionStats(task.section);
         saveData();
     }
 }
@@ -679,15 +718,15 @@ function updateParentCheckboxes(task) {
 
             const parentCheckbox = document.getElementById(parentTaskDefinition.id);
             const parentContainer = parentCheckbox ? parentCheckbox.closest(".parent-task-container") : null;
-            const parentTextSpan = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
+            const parentDescription = parentContainer ? parentContainer.querySelector(".parent-task-header .task-description") : null;
 
             if (parentCheckbox) { parentCheckbox.checked = allSubtasksDone; }
-            if (parentTextSpan) { parentTextSpan.classList.toggle("checked", allSubtasksDone); }
+            if (parentDescription) { parentDescription.classList.toggle("checked", allSubtasksDone); }
         }
 
         t = parentTaskDefinition;  // move up a level
     }
-    calcSectionStats(task.id.split("_")[0]);
+    calcSectionStats(task.section);
     saveData();
 }
 
@@ -879,35 +918,6 @@ function makeInfoLine(task, appendTo) {
     }
 }
 
-function getTaskById(id) {
-    for (const group in tasks) {
-        for (const task of tasks[group]) {
-            if (task.id === id) {
-                return task;
-            }
-            const subtaskFound = _getSubtaskById(task, id);
-            if (subtaskFound) {
-                return subtaskFound;
-            }
-        }
-    }
-}
-
-function _getSubtaskById(task, id) {
-    if ("subtasks" in task) {
-        for (const subtask of task.subtasks) {
-            if (subtask.id === id) {
-                return subtask;
-            }
-            const subtaskFound = _getSubtaskById(subtask, id);
-            if (subtaskFound) {
-                return subtaskFound;
-            }
-        }
-    }
-    return undefined;
-}
-
 function populateSection(section) {
     const sectionElement = document.querySelector(`#${section}-tasks-content ul`);
     const taskList = tasks[section];
@@ -1044,18 +1054,17 @@ function showHiddenTasksAction(parent, taskList, stat) {
 
 function hiddenTasksButtonAction(taskElement, task, stat) {
     return () => {
-        const section = task.id.split("_")[0];
         taskElement.classList.add("hidden-task"); // unhiding the task hides it from the hidden task list
 
         if (stat === "completed") {
             document.getElementById(task.id).dispatchEvent(new CustomEvent("change", { detail: false }));
-            populateSection(section);
+            populateSection(task.section);
         } else {
             checklistData[C.TASKLIST_STAT_PROPERTIES[stat]][task.id] = false;
             document.getElementById(task.id).closest(".task-item").classList.remove("hidden-task");
             updateParentCheckboxes(task);
             if (task.parentId) { calcSectionStats(task.parentId); }
-            calcSectionStats(section);
+            calcSectionStats(task.section);
         }
 
         saveData();

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -34,7 +34,7 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.3";
+export const APP_VERSION = "5.3";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
 const WARFRAME_VERSION = "43.0.8";

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -5,6 +5,7 @@ import {
     modulo,
     newChecklistData,
     iconURL,
+    makeTaskIcon,
     makeCycleIcon,
     formatTimestamp,
     getMostRecentMondayMidnightUTC,
@@ -33,10 +34,10 @@ const dailyBackgroundImageIds = [
     'bg-image-4',
     // Add more IDs if you add more background image divs in HTML
 ];
-const APP_VERSION = "5.2";
+const APP_VERSION = "5.3";
 const GIT_COMMIT_HASH_LONG = import.meta.env.VITE_GIT_COMMIT_HASH;
 const GIT_COMMIT_HASH = GIT_COMMIT_HASH_LONG.slice(0,7);
-const WARFRAME_VERSION = "43.0.6";
+const WARFRAME_VERSION = "43.0.7";
 const THEME_STORAGE_KEY = 'warframeChecklistTheme';
 
 // only update DATA_STORAGE_KEY when the data storage format changes
@@ -68,8 +69,8 @@ _prepTasks();
 let bodyElement, themeToggleButton, hamburgerButton, optionsMenu, resetDailyButton, resetWeeklyButton, resetButton,
     unhideTasksButton, lastSavedTimestampElement, saveStatusElement, sectionToggles, dailyResetTimeElement,
     weeklyResetTimeElement, errorDisplayElement, errorMessageElement, errorCloseButton, errorCopyButton,
-    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, backgroundDivs,
-    hideCompletedToggle = [];
+    appVersionElement, gitHashElement, wfVersionElement, scheduleDialog, moreInfoDialog, hiddenTasksDialog,
+    backgroundDivs, hideCompletedToggle = [];
 
 
 // --- State Variables ---
@@ -90,27 +91,28 @@ let countdownInterval;
 
 function initializeDOMElements() {
     bodyElement = document.body;
-    themeToggleButton = document.getElementById('theme-toggle-button');
-    hamburgerButton = document.getElementById('hamburger-button');
+    themeToggleButton = document.getElementById("theme-toggle-button");
+    hamburgerButton = document.getElementById("hamburger-button");
     optionsMenu = document.getElementById("options-menu");
-    resetDailyButton = document.getElementById('reset-daily-button');
-    resetWeeklyButton = document.getElementById('reset-weekly-button');
-    resetButton = document.getElementById('reset-button');
-    unhideTasksButton = document.getElementById('unhide-tasks-button');
-    lastSavedTimestampElement = document.getElementById('last-saved-timestamp');
-    saveStatusElement = document.getElementById('save-status');
-    sectionToggles = document.querySelectorAll('.section-toggle');
-    dailyResetTimeElement = document.getElementById('daily-reset-local-time');
-    weeklyResetTimeElement = document.getElementById('weekly-reset-local-time');
-    errorDisplayElement = document.getElementById('error-display');
-    errorMessageElement = document.getElementById('error-message');
-    errorCloseButton = document.getElementById('error-close-button');
-    errorCopyButton = document.getElementById('error-copy-button');
-    appVersionElement = document.querySelector('.version-text');
-    gitHashElement = document.querySelector('.git-hash-text');
-    wfVersionElement = document.querySelector('.warframe-version-text');
+    resetDailyButton = document.getElementById("reset-daily-button");
+    resetWeeklyButton = document.getElementById("reset-weekly-button");
+    resetButton = document.getElementById("reset-button");
+    unhideTasksButton = document.getElementById("unhide-tasks-button");
+    lastSavedTimestampElement = document.getElementById("last-saved-timestamp");
+    saveStatusElement = document.getElementById("save-status");
+    sectionToggles = document.querySelectorAll(".section-toggle");
+    dailyResetTimeElement = document.getElementById("daily-reset-local-time");
+    weeklyResetTimeElement = document.getElementById("weekly-reset-local-time");
+    errorDisplayElement = document.getElementById("error-display");
+    errorMessageElement = document.getElementById("error-message");
+    errorCloseButton = document.getElementById("error-close-button");
+    errorCopyButton = document.getElementById("error-copy-button");
+    appVersionElement = document.querySelector(".version-text");
+    gitHashElement = document.querySelector(".git-hash-text");
+    wfVersionElement = document.querySelector(".warframe-version-text");
     scheduleDialog = document.getElementById("cycle-schedule");
     moreInfoDialog = document.getElementById("more-info");
+    hiddenTasksDialog = document.getElementById("hidden-tasklist");
     hideCompletedToggle = document.getElementById("hide-completed");
 
     backgroundDivs = [];
@@ -451,14 +453,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     });
 
     // Task Icon
-    const icon = document.createElement('img');
-    if (task.icon) {
-        icon.src = iconURL(`tasks/${task.icon}`);
-        icon.classList.add("task-icon");
-        if (!task.noIconFilter) {
-            icon.classList.add('icon-filter')
-        }
-    }
+    const icon = makeTaskIcon(task);
 
     // Hide/Notif Controls
     const controlsContainer = document.createElement('div');
@@ -610,6 +605,8 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
             taskDescription.classList.toggle('checked', currentlyChecked);
 
             task.subtasks.forEach((subtask) => {
+                if (checklistData.skippedTasks[subtask.id] || checklistData.hiddenTasks[subtask.id]) { return; }
+
                 const subCheckbox = document.getElementById(subtask.id);
 
                 // this is kind of a stupid hack: We can recursively fire events with dispatchEvent, but those events
@@ -702,12 +699,12 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 }
 
 function taskDialogHeaderSetup(task, dialog) {
-    dialog.querySelector(":scope header .title").innerText = task.title;
+    dialog.querySelector(":scope header .task-title").innerHTML = task?.title || "";
 
     let taskIcon = dialog.querySelector(":scope .menu-title img.task-icon");
     taskIcon.className = "task-icon"; // remove possible `icon-filter` from previous opening
     taskIcon.src = "";
-    if (task.icon) {
+    if (task?.icon) {
         taskIcon.src = iconURL(`tasks/${task.icon}`);
         if (!task.noIconFilter) {
             taskIcon.classList.add("icon-filter");
@@ -927,7 +924,6 @@ function populateSection(section) {
  * @param queryFrom - DOM element to find the stats box in. Defaults to `document`. Override this if the element is not inserted into the document yet.
  */
 function calcSectionStats(parent, queryFrom=document) {
-    console.log(`calcSectionStats(${parent})`);
     let taskList;
     if (parent.includes("_")) {
         taskList = getTaskById(parent).subtasks;
@@ -936,38 +932,130 @@ function calcSectionStats(parent, queryFrom=document) {
     }
     const statsBox = queryFrom.querySelector(`#stats_${parent} > div`);
 
-    let completed = 0;
-    let skipped = 0;
-    let hidden = 0;
+    let stats = {
+        completed: 0,
+        skipped: 0,
+        hidden: 0
+    }
     for (const task of taskList) {
-        if (checklistData.progress[task.id]) { completed++; }
-        if (checklistData.skippedTasks[task.id]) { skipped++; }
-        if (checklistData.hiddenTasks[task.id]) { hidden++; }
+        if (checklistData.progress[task.id])     { stats.completed++; }
+        if (checklistData.skippedTasks[task.id]) { stats.skipped++; }
+        if (checklistData.hiddenTasks[task.id])  { stats.hidden++; }
     }
 
     statsBox.innerHTML = "";
 
-    const completedBox = document.createElement("span");
-    completedBox.classList.add("stats-completed");
-    completedBox.dataset.count = completed;
-    completedBox.innerText = `+${completed} completed`;
-    statsBox.appendChild(completedBox);
+    const statIcons = {
+        completed: "✔",
+        skipped: svgIcons.skipIcon,
+        hidden: svgIcons.hideIcon
+    }
 
-    const skippedBox = document.createElement("span");
-    skippedBox.classList.add("stats-skipped");
-    skippedBox.dataset.count = skipped;
-    skippedBox.innerText = `+${skipped} skipped`;
-    statsBox.appendChild(skippedBox);
+    for (const stat in stats) {
+        const statButton = document.createElement("button");
+        statButton.type = "button";
+        statButton.classList.add(`stats-${stat}`);
+        statButton.dataset.count = stats[stat];
+        statButton.innerHTML = `${statIcons[stat]} +${stats[stat]} ${C.TASKLIST_STAT_NAMES[stat]}`;
+        statButton.addEventListener("click", showHiddenTasksAction(parent, taskList, stat));
+        statsBox.appendChild(statButton);
+    }
+}
 
-    const hiddenBox = document.createElement("span");
-    hiddenBox.classList.add("stats-hidden");
-    hiddenBox.dataset.count = hidden;
-    hiddenBox.innerText = `+${hidden} hidden`;
-    statsBox.appendChild(hiddenBox);
+function showHiddenTasksAction(parent, taskList, stat) {
+    return () => {
+        // Dialog Title
+        const prefix = hiddenTasksDialog.querySelector(".menu-title > span:first-of-type");
+        const suffix = hiddenTasksDialog.querySelector(".menu-title > span:last-of-type");
+        if (parent.includes("_")) { // subtask list
+            const parentTask = getTaskById(parent);
+            taskDialogHeaderSetup(parentTask, hiddenTasksDialog);
+            prefix.innerText = `${C.TASKLIST_STAT_NAMES[stat]} subtasks of `;
+            suffix.innerText = "";
+        } else { // section list
+            taskDialogHeaderSetup({ title: C.SECTION_NAMES[parent] }, hiddenTasksDialog); // use a fake task to set the task title to the section name
+            prefix.innerText = `${C.TASKLIST_STAT_NAMES[stat]} `;
+            suffix.innerText = " Tasks";
+        }
+
+        // Task List
+        const ul = hiddenTasksDialog.querySelector("ul");
+        ul.classList = stat;
+        ul.innerHTML = "";
+        for (const task of taskList) {
+            if (checklistData[C.TASKLIST_STAT_PROPERTIES[stat]][task.id]) {
+                const li = document.createElement("li");
+                li.classList.add("task-expander");
+
+                const taskItem = document.createElement("div");
+                taskItem.classList.add("task-item");
+
+                let controlButton;
+                if (stat === "completed") {
+                    controlButton = document.createElement("input");
+                    controlButton.type = "checkbox";
+                    controlButton.checked = true;
+                } else {
+                    controlButton = document.createElement("button");
+                    controlButton.type = "button";
+                }
+
+                if (stat === "completed") {
+                    controlButton.title = controlButton.ariaLabel = `Uncheck task: ${task.title}`;
+                } else if (stat === "skipped") {
+                    controlButton.innerHTML = svgIcons.skipIcon;
+                    controlButton.title = controlButton.ariaLabel = `Unskip task: ${task.title}`;
+                } else if (stat === "hidden") {
+                    controlButton.innerHTML = svgIcons.unhideIcon;
+                    controlButton.title = controlButton.ariaLabel = `Unhide task: ${task.title}`;
+                }
+
+                controlButton.addEventListener("click", hiddenTasksButtonAction(taskItem, task, stat));
+                taskItem.appendChild(controlButton);
+
+                const icon = makeTaskIcon(task);
+                if (icon) { taskItem.appendChild(icon); }
+
+                const title = document.createElement("div");
+                title.classList.add("task-title", "task-description");
+                title.innerHTML = task.title;
+                taskItem.appendChild(title);
+
+                li.appendChild(taskItem);
+                ul.appendChild(li);
+            }
+        }
+
+        hiddenTasksDialog.showModal();
+    }
+}
+
+function hiddenTasksButtonAction(taskElement, task, stat) {
+    return () => {
+        const section = task.id.split("_")[0];
+        taskElement.classList.add("hidden-task"); // unhiding the task hides it from the hidden task list
+
+        if (stat === "completed") {
+            document.getElementById(task.id).dispatchEvent(new CustomEvent("change", { detail: false }));
+            populateSection(section);
+        } else {
+            checklistData[C.TASKLIST_STAT_PROPERTIES[stat]][task.id] = false;
+            document.getElementById(task.id).closest(".task-item").classList.remove("hidden-task");
+            if (task.parentId) { calcSectionStats(task.parentId); }
+            calcSectionStats(section);
+        }
+
+        saveData();
+
+        // close dialog if tasklist is empty
+        if (!hiddenTasksDialog.querySelector("li > :not(.hidden-task)")) {
+            hiddenTasksDialog.close();
+        }
+    }
 }
 
 function resetSpecificButtonState(buttonElement, defaultText, stateKey) {
-    if (!buttonElement || !confirmState[stateKey]) { return };
+    if (!buttonElement || !confirmState[stateKey]) { return; }
     clearTimeout(confirmState[stateKey].timeout);
     confirmState[stateKey].timeout = null;
     confirmState[stateKey].isConfirming = false;

--- a/sources/js/app.js
+++ b/sources/js/app.js
@@ -3,6 +3,7 @@ console.log(`vite mode: ${import.meta.env.MODE}`);
 
 import {
     modulo,
+    newChecklistData,
     iconURL,
     makeCycleIcon,
     formatTimestamp,
@@ -79,20 +80,9 @@ const confirmState = {
     unhide: { timeout: null, isConfirming: false }
 };
 
-let checklistData = {
-    progress: {},
-    lastSaved: null,
-    lastDailyReset: null,
-    lastWeeklyReset: null,
-    hiddenTasks: {},
-    manuallyHiddenSections: {},
-    lastTaskResetTimes: {},
-    notificationPreferences: {},
-    notificationsSent: {},
-    hideCompletedTasks: false
-};
+let checklistData = newChecklistData();
 
-let currentTheme = 'dark';
+let currentTheme = "dark";
 let saveStatusTimeout;
 let countdownInterval;
 
@@ -374,8 +364,9 @@ function otherTaskReset(task) {
     const lastResetCycleNumber = calcCycleNumber(task, lastResetTime);
     if (cycleNumber > lastResetCycleNumber || !calcTaskTimes(task, now).isAvailable) {
         // Reset task
-        if (checklistData.progress[task.id] && !checklistData.hiddenTasks[task.id]) {
+        if (checklistData.progress[task.id] || checklistData.skippedTasks[task.id]) {
             checklistData.progress[task.id] = false;
+            checklistData.skippedTasks[task.id] = false;
             console.log(`Resetting task: ${task.id}`);
             didReset = true;
         }
@@ -435,7 +426,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
 
     const taskItem = document.createElement("div");
     taskItem.classList.add("task-item");
-    if (checklistData.hiddenTasks[task.id]) {
+    if (checklistData.hiddenTasks[task.id] || checklistData.skippedTasks[task.id]) {
         taskItem.classList.add("hidden-task");
     }
 
@@ -473,35 +464,55 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
     const controlsContainer = document.createElement('div');
 
     // Notif Button
-    if (task.id.startsWith('other_')) {
-        const notificationButton = document.createElement('button');
-        notificationButton.classList.add('notification-toggle-btn');
-        notificationButton.setAttribute('aria-label', `Toggle notifications for ${task.title}`);
+    if (task.id.startsWith("other_")) {
+        const notificationButton = document.createElement("button");
+        notificationButton.classList.add("notification-toggle-btn", "task-ctrl-btn");
+        notificationButton.setAttribute("aria-label", `Toggle notifications for ${task.title}`);
         notificationButton.title = `Toggle notifications for ${task.title}`;
 
         notificationButton.innerHTML = svgIcons.bellIcon;
         if (checklistData.notificationPreferences[task.id]) { notificationButton.classList.add("active"); }
 
-        notificationButton.addEventListener('click', async (e) => {
+        notificationButton.addEventListener("click", async (e) => {
             e.stopPropagation();
             const permissionGranted = await requestNotificationPermission();
             if (permissionGranted) {
                 checklistData.notificationPreferences[task.id] = !checklistData.notificationPreferences[task.id];
-                notificationButton.classList.toggle('active', checklistData.notificationPreferences[task.id]);
+                notificationButton.classList.toggle("active", checklistData.notificationPreferences[task.id]);
                 saveData(false);
-                console.log(`Notifications for ${task.id} ${checklistData.notificationPreferences[task.id] ? 'enabled' : 'disabled'}`);
+                console.log(`Notifications for ${task.id} ${checklistData.notificationPreferences[task.id] ? "enabled" : "disabled"}`);
             }
         });
         controlsContainer.appendChild(notificationButton);
     }
 
+    // Skip Button
+    const skipButton = document.createElement("button");
+    let when = "this cycle";
+    if (task.id.startsWith("daily_")) { when = "today"; }
+    else if (task.id.startsWith("weekly_")) { when = "this week"; }
+    skipButton.classList.add("task-ctrl-btn");
+    skipButton.setAttribute("aria-label", `Skip task ${when}: ${task.title}`);
+    skipButton.title = `Skip task ${when}: ${task.title}`;
+    skipButton.innerHTML = svgIcons.skipIcon;
+    skipButton.addEventListener("click", (e) => {
+        e.stopPropagation();
+        checklistData.skippedTasks[task.id] = true;
+        taskItem.classList.add("hidden-task");
+        updateSectionControls(taskItem.closest("section").id);
+        if (task.parentId) { calcSectionStats(task.parentId); }
+        calcSectionStats(task.id.split("_")[0]);
+        saveData(false);
+    });
+    controlsContainer.appendChild(skipButton);
+
     // Hide Button
-    const hideButton = document.createElement('button');
-    hideButton.classList.add('hide-task-btn');
-    hideButton.setAttribute('aria-label', `Hide task: ${task.title}`);
+    const hideButton = document.createElement("button");
+    hideButton.classList.add("task-ctrl-btn");
+    hideButton.setAttribute("aria-label", `Hide task: ${task.title}`);
     hideButton.title = `Hide task: ${task.title}`;
     hideButton.innerHTML = svgIcons.hideIcon;
-    hideButton.addEventListener('click', (e) => {
+    hideButton.addEventListener("click", (e) => {
         e.stopPropagation();
         checklistData.hiddenTasks[task.id] = true;
         taskItem.classList.add("hidden-task");
@@ -528,12 +539,12 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         taskDescription.classList.add("task-description");
         const taskTitle = document.createElement("span");
         taskTitle.classList.add("task-title");
-        taskTitle.textContent = task.title;
+        taskTitle.innerHTML = task.title;
         taskDescription.appendChild(taskTitle);
         if (task.text) {
-            taskTitle.textContent += ": ";
+            taskTitle.innerHTML += ": ";
             const taskText = document.createElement("span");
-            taskText.textContent = task.text;
+            taskText.innerHTML = task.text;
             taskText.classList.add("task-text");
             taskDescription.appendChild(taskText);
         }
@@ -622,12 +633,12 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
         // Task Text
         const taskTitle = document.createElement("span");
         taskTitle.classList.add("task-title");
-        taskTitle.textContent = task.title;
+        taskTitle.innerHTML = task.title;
         label.appendChild(taskTitle);
         if (task.text) {
-            taskTitle.textContent += ": ";
+            taskTitle.innerHTML += ": ";
             const taskText = document.createElement("span");
-            taskText.textContent = task.text;
+            taskText.innerHTML = task.text;
             taskText.classList.add("task-text");
             label.appendChild(taskText);
         }
@@ -669,7 +680,7 @@ function createChecklistItem(task, isChecked, isSubtask = false) {
                 let parentTaskDefinition = getTaskById(t.parentId);
 
                 if (parentTaskDefinition && parentTaskDefinition.subtasks) {
-                    const allSubtasksDone = parentTaskDefinition.subtasks.every((st) => (checklistData.progress[st.id] || checklistData.hiddenTasks[st.id]));
+                    const allSubtasksDone = parentTaskDefinition.subtasks.every((st) => (checklistData.progress[st.id] || checklistData.hiddenTasks[st.id] || checklistData.skippedTasks[st.id]));
                     checklistData.progress[parentTaskDefinition.id] = allSubtasksDone;
 
                     const parentCheckbox = document.getElementById(parentTaskDefinition.id);
@@ -926,9 +937,11 @@ function calcSectionStats(parent, queryFrom=document) {
     const statsBox = queryFrom.querySelector(`#stats_${parent} > div`);
 
     let completed = 0;
+    let skipped = 0;
     let hidden = 0;
     for (const task of taskList) {
         if (checklistData.progress[task.id]) { completed++; }
+        if (checklistData.skippedTasks[task.id]) { skipped++; }
         if (checklistData.hiddenTasks[task.id]) { hidden++; }
     }
 
@@ -939,6 +952,12 @@ function calcSectionStats(parent, queryFrom=document) {
     completedBox.dataset.count = completed;
     completedBox.innerText = `+${completed} completed`;
     statsBox.appendChild(completedBox);
+
+    const skippedBox = document.createElement("span");
+    skippedBox.classList.add("stats-skipped");
+    skippedBox.dataset.count = skipped;
+    skippedBox.innerText = `+${skipped} skipped`;
+    statsBox.appendChild(skippedBox);
 
     const hiddenBox = document.createElement("span");
     hiddenBox.classList.add("stats-hidden");
@@ -998,6 +1017,7 @@ function handleResetConfirmation(buttonElement, confirmKey, defaultText, resetAc
 
 function resetAllAction() {
     checklistData.progress = {};
+    checklistData.skippedTasks = {};
     saveData();
     ["daily", "weekly", "other"].forEach(populateSection);
     console.log("Checklist reset complete.");
@@ -1015,17 +1035,18 @@ function resetSection(section, resetAltRefTasks=false) {
     function resetTask(task) {
         if (task.ref && !resetAltRefTasks) {
             didReset += otherTaskReset(task);
-        } else if (checklistData.progress[task.id] && !checklistData.hiddenTasks[task.id]) {
+        } else if (checklistData.progress[task.id] || checklistData.skippedTasks[task.id]) {
             checklistData.progress[task.id] = false;
+            checklistData.skippedTasks[task.id] = false;
             didReset++;
         }
-        if (task.subtasks) {task.subtasks.forEach(resetTask);}
+        if (task.subtasks) { task.subtasks.forEach(resetTask); }
     }
     tasks[section].forEach(resetTask);
 
     const now = new Date().toISOString();
-    if (section === "daily") {checklistData.lastDailyReset = now;}
-    else if (section === "weekly") {checklistData.lastWeeklyReset = now;}
+    if (section === "daily") { checklistData.lastDailyReset = now; }
+    else if (section === "weekly") { checklistData.lastWeeklyReset = now; }
     saveData();
     if (didReset) {
         populateSection(section);
@@ -1057,13 +1078,13 @@ function handleSectionToggle(event) {
 
 function unhideAllAction() {
     checklistData.hiddenTasks = {};
+    checklistData.skippedTasks = {};
     checklistData.manuallyHiddenSections = {};
     saveData(false);
 
-    document.querySelectorAll(".task-item.hidden-task").forEach((item) => item.classList.remove("hidden-task"));
     document.querySelectorAll("section.section-is-hidden-by-user").forEach((section) => section.classList.remove("section-is-hidden-by-user"));
-
     ["daily", "weekly", "other"].forEach(populateSection);
+
     console.log("All tasks and sections unhidden.");
     optionsMenu.close();
 }
@@ -1141,6 +1162,7 @@ function loadData() {
                 checklistData.lastDailyReset = parsedData.lastDailyReset || null;
                 checklistData.lastWeeklyReset = parsedData.lastWeeklyReset || null;
                 checklistData.hiddenTasks = parsedData.hiddenTasks || {};
+                checklistData.skippedTasks = parsedData.skippedTasks || {};
                 checklistData.manuallyHiddenSections = parsedData.manuallyHiddenSections || {};
                 checklistData.lastTaskResetTimes = parsedData.lastTaskResetTimes || {};
                 checklistData.notificationPreferences = parsedData.notificationPreferences || {};
@@ -1150,7 +1172,7 @@ function loadData() {
         } catch (e) {
             console.error("Error parsing saved data:", e);
             displayError("Failed to load saved progress. Data might be corrupted.");
-            checklistData = { progress: {}, lastSaved: null, lastDailyReset: null, lastWeeklyReset: null, hiddenTasks: {}, manuallyHiddenSections: {}, lastTaskResetTimes: {}, notificationPreferences: {}, notificationsSent: {}, hideCompletedTasks: false };
+            checklistData = newChecklistData();
         }
     }
 }

--- a/sources/js/constants.js
+++ b/sources/js/constants.js
@@ -7,3 +7,21 @@ export const MILLISECONDS_PER_DAY = 24 * MILLISECONDS_PER_HOUR;
 export const SERVER_TIMEZONE = "America/Toronto";  // used for determining Daylight Saving Time
 
 export const BASE_OF_OPERATIONS_TOOLTIP = '<span class="tooltip" title="Orbiter, Drifter\'s Camp, or Backroom">Base of Operations</span>';
+
+export const TASKLIST_STAT_NAMES = {
+    "completed": "Completed",
+    "skipped": "Skipped",
+    "hidden": "Hidden",
+};
+
+export const TASKLIST_STAT_PROPERTIES = {
+    "completed": "progress",
+    "skipped": "skippedTasks",
+    "hidden": "hiddenTasks"
+};
+
+export const SECTION_NAMES = {
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "other": "Other",
+};

--- a/sources/js/functions.js
+++ b/sources/js/functions.js
@@ -32,6 +32,22 @@ export function iconURL(iconName) {
     return taskIcons["../img/icons/" + iconName];
 }
 
+/** returns a new element of the icon of the given task, or null if it doesn't have one
+ */
+export function makeTaskIcon(task) {
+    if (task.icon) {
+        const icon = document.createElement("img");
+        icon.src = iconURL(`tasks/${task.icon}`);
+        icon.classList.add("task-icon");
+        if (!task.noIconFilter) {
+            icon.classList.add("icon-filter");
+        }
+        return icon;
+    } else {
+        return null;
+    }
+}
+
 export function makeCycleIcon(cycleData) {
     if (cycleData.icon) {
         const src = iconURL(`cycles/${cycleData.icon}`)

--- a/sources/js/functions.js
+++ b/sources/js/functions.js
@@ -183,3 +183,19 @@ export function factionIcon(name) {
     const src = iconURL(`tasks/syndicates/${name}`);
     return `<img class="icon-filter inline-icon" src="${src}">`;
 }
+
+/**
+ * Generate a "section stats" element, which shows things like number of hidden tasks in a section or subtask list
+ *
+ * @param parent - what task list to count stats on. This can be the name of a section, or the id of a task with subtasks.
+ * @returns a new DOM Element. Does not insert it into the document.
+ */
+export function makeSectionStats(parent) {
+    const statsContainer = document.createElement("li");
+    statsContainer.classList.add("list-stats");
+    statsContainer.id = `stats_${parent}`;
+    const statsBox = document.createElement("div");
+    statsBox.innerHTML = "...";
+    statsContainer.appendChild(statsBox);
+    return statsContainer;
+}

--- a/sources/js/functions.js
+++ b/sources/js/functions.js
@@ -23,7 +23,8 @@ export function newChecklistData() {
         lastTaskResetTimes: {},
         notificationPreferences: {},
         notificationsSent: {},
-        hideCompletedTasks: false
+        hideCompletedTasks: false,
+        collapsedParentTasks: {},
     };
 }
 

--- a/sources/js/functions.js
+++ b/sources/js/functions.js
@@ -11,6 +11,22 @@ export function modulo(n, d) {
     return ((n % d) + d) % d;
 }
 
+export function newChecklistData() {
+    return {
+        progress: {},
+        lastSaved: null,
+        lastDailyReset: null,
+        lastWeeklyReset: null,
+        hiddenTasks: {},
+        skippedTasks: {},
+        manuallyHiddenSections: {},
+        lastTaskResetTimes: {},
+        notificationPreferences: {},
+        notificationsSent: {},
+        hideCompletedTasks: false
+    };
+}
+
 const taskIcons = import.meta.glob("../img/icons/**/*.png", {eager: true, query: '?url', import: 'default'});
 export function iconURL(iconName) {
     return taskIcons["../img/icons/" + iconName];

--- a/sources/js/icons.js
+++ b/sources/js/icons.js
@@ -1,4 +1,6 @@
-// Icons from https://heroicons.com/
+/* Heroicons https://heroicons.com/
+ * MIT license https://github.com/tailwindlabs/heroicons/blob/master/LICENSE
+ */
 
 const chevronDownOutline =
 `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
@@ -90,6 +92,17 @@ const calendarDays16 =
     />
 </svg>`
 
+
+/* Lucide icons https://github.com/lucide-icons/lucide
+ * ISC license https://github.com/lucide-icons/lucide/blob/main/LICENSE
+ */
+
+// https://icon-sets.iconify.design/lucide/skip-forward/
+const skipForward =
+`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 4v16M6.029 4.285A2 2 0 0 0 3 6v12a2 2 0 0 0 3.029 1.715l9.997-5.998a2 2 0 0 0 .003-3.432z" />
+</svg>`
+
 export {
     chevronDownOutline as collapseIcon,
     eyeSlashOutline as hideIcon,
@@ -100,4 +113,5 @@ export {
     clipboardDocumentCheck16 as prereqIcon,
     informationCircle16 as infoIcon,
     calendarDays16 as cycleIcon,
+    skipForward as skipIcon,
 };

--- a/sources/js/icons.js
+++ b/sources/js/icons.js
@@ -17,6 +17,16 @@ const eyeSlashOutline =
     />
 </svg>`;
 
+const eyeOutline =
+`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round"
+        d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5
+            c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5
+            c-4.638 0-8.573-3.007-9.963-7.178Z"
+    />
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+</svg>`
+
 const bellOutline =
 `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
     <path stroke-linecap="round" stroke-linejoin="round"
@@ -100,12 +110,15 @@ const calendarDays16 =
 // https://icon-sets.iconify.design/lucide/skip-forward/
 const skipForward =
 `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 4v16M6.029 4.285A2 2 0 0 0 3 6v12a2 2 0 0 0 3.029 1.715l9.997-5.998a2 2 0 0 0 .003-3.432z" />
+	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+        d="M21 4v16M6.029 4.285A2 2 0 0 0 3 6v12a2 2 0 0 0 3.029 1.715l9.997-5.998a2 2 0 0 0 .003-3.432z"
+    />
 </svg>`
 
 export {
     chevronDownOutline as collapseIcon,
     eyeSlashOutline as hideIcon,
+    eyeOutline as unhideIcon,
     bellOutline as bellIcon,
     mapPin16 as locationIcon,
     user24 as npcIcon,

--- a/sources/js/tasks.json
+++ b/sources/js/tasks.json
@@ -2,40 +2,46 @@
     "daily": [
         {
             "id": "daily_login",
-            "text": "Log in: Collect the daily login reward.",
+            "title": "Log in",
+            "text": "Collect the daily login reward.",
             "icon": "LotusFlower.png"
         },
         {
             "id": "daily_craft_forma",
-            "text": "Crafting (Forma): Start building a new Forma (and collect finished ones).",
+            "title": "Crafting (Forma)",
+            "text": "Start building a new Forma (and collect finished ones).",
             "icon": "IconBuild.png",
             "location": "Base of Operations",
             "terminal": "Foundry"
         },
         {
             "id": "daily_craft_other",
-            "text": "Crafting (Other): Craft other daily resources/items using reusable blueprints (check Foundry/companion app).",
+            "title": "Crafting (Other)",
+            "text": "Craft other daily resources/items using reusable blueprints (check Foundry/companion app).",
             "icon": "IconBuild.png",
             "location": "Base of Operations",
             "terminal": "Foundry"
         },
         {
             "id": "daily_first_win_bonus",
-            "text": "Daily First Win Bonus: Get double base credit reward on your first mission.",
+            "title": "Daily First Win Bonus",
+            "text": "Get double base credit reward on your first mission.",
             "icon": "DoubleCreditEvent.png",
             "location": "Base of Operations",
             "terminal": "Navigation"
         },
         {
             "id": "daily_syndicate_gain",
-            "text": "Faction Syndicates: Gain daily standing cap with your pledged Syndicate(s).",
+            "title": "Faction Syndicates",
+            "text": "Gain daily standing cap with your pledged Syndicate(s).",
             "icon": "ReputationSmall.png",
             "prereq": "Mastery Rank 3",
             "info": "Gain affinity in any mission to increase faction standing"
         },
         {
             "id": "daily_syndicate_spend",
-            "text": "Faction Syndicates: If maxed on standing, spend it (Relic packs, Vosfor packs, etc.).",
+            "title": "Faction Syndicates",
+            "text": "If maxed on standing, spend it (Relic packs, Vosfor packs, etc.).",
             "icon": "ReputationSmall.png",
             "location": "Base of Operations/Any Relay",
             "terminal": "Syndicates",
@@ -43,81 +49,82 @@
         },
         {
             "id": "daily_world_syndicate_parent",
-            "text": "World Syndicates (Standing)",
+            "title": "World Syndicates",
+            "text": "Gain standing.",
             "icon": "ReputationSmall.png",
             "subtasks": [
                 {
                     "id": "daily_world_syndicate_simaris",
-                    "text": "Cephalon Simaris",
+                    "title": "Cephalon Simaris",
                     "icon": "syndicates/IconSimaris.png",
                     "location": "Any Relay"
                 },
                 {
                     "id": "daily_world_syndicate_ostron",
-                    "text": "Ostron",
+                    "title": "Ostron",
                     "icon": "syndicates/IconCetusElder.png",
                     "location": "Cetus, Earth",
                     "prereq": "Saya's Vigil"
                 },
                 {
                     "id": "daily_world_syndicate_quills",
-                    "text": "The Quills",
+                    "title": "The Quills",
                     "icon": "syndicates/TheQuillsSigil.png",
                     "location": "Cetus, Earth",
                     "prereq": "The War Within"
                 },
                 {
                     "id": "daily_world_syndicate_solaris",
-                    "text": "Solaris United",
+                    "title": "Solaris United",
                     "icon": "syndicates/SolarisUnited1.png",
                     "location": "Fortuna, Venus",
                     "prereq": "Vox Solaris (Quest)"
                 },
                 {
                     "id": "daily_world_syndicate_vox",
-                    "text": "Vox Solaris",
+                    "title": "Vox Solaris",
                     "icon": "syndicates/IconSolaris.png",
                     "location": "Fortuna, Venus",
                     "prereq": "The War Within"
                 },
                 {
                     "id": "daily_world_syndicate_ventkids",
-                    "text": "Ventkids",
+                    "title": "Ventkids",
                     "icon": "syndicates/FactionVentKidz.png",
                     "location": "Fortuna, Venus",
                     "prereq": "Vox Solaris (Quest)"
                 },
                 {
                     "id": "daily_world_syndicate_entrati",
-                    "text": "Entrati",
+                    "title": "Entrati",
                     "icon": "syndicates/IconEntrati.png",
                     "location": "Necralisk, Deimos",
                     "prereq": "Heart of Deimos"
                 },
                 {
                     "id": "daily_world_syndicate_necraloid",
-                    "text": "Necraloid",
+                    "title": "Necraloid",
                     "icon": "syndicates/Loid.png",
                     "location": "Necralisk, Deimos",
                     "prereq": "The War Within"
                 },
                 {
                     "id": "daily_world_syndicate_holdfasts",
-                    "text": "The Holdfasts",
+                    "title": "The Holdfasts",
                     "icon": "syndicates/TheHoldfastsIcon.png",
                     "location": "Chrysalith, Zariman",
                     "prereq": "Angels of the Zariman"
                 },
                 {
                     "id": "daily_world_syndicate_cavia",
-                    "text": "Cavia",
+                    "title": "Cavia",
                     "icon": "syndicates/FactionSigilCavia.png",
                     "location": "Sanctum Anatomica, Deimos",
                     "prereq": "Whispers in the Walls"
                 },
                 {
                     "id": "daily_world_syndicate_hex",
-                    "text": "The Hex",
+                    "title": "The Hex",
                     "icon": "syndicates/HexIcon.png",
                     "location": "Höllvania Central Mall",
                     "prereq": "The Hex (Quest)"
@@ -126,7 +133,8 @@
         },
         {
             "id": "daily_sortie",
-            "text": "Sortie: Complete the 3 daily Sortie missions.",
+            "title": "Sortie",
+            "text": "Complete the 3 daily Sortie missions.",
             "icon": "Sortie.png",
             "location": "Base of Operations",
             "terminal": "Navigation",
@@ -136,63 +144,66 @@
         },
         {
             "id": "daily_focus",
-            "text": "Focus: Max out daily Focus gain (e.g., via Sanctuary Onslaught).",
+            "title": "Focus",
+            "text": "Max out daily Focus gain (e.g., via Sanctuary Onslaught).",
             "icon": "FocusLensFocus.png",
             "prereq": "The Second Dream"
         },
         {
             "id": "daily_steel_path",
-            "text": "Steel Path Incursions: Complete daily Steel Path missions for Steel Essence.",
+            "title": "Steel Path Incursions",
+            "text": "Complete daily Steel Path missions for Steel Essence.",
             "icon": "SteelEssenceIcon.png",
             "prereq": "Steel Path unlocked"
         },
         {
             "id": "daily_kim_parent",
-            "text": "KIM: complete daily chats with protoframes",
+            "title": "KIM",
+            "text": "complete daily chats with protoframes",
             "location": "Base of Operations",
             "terminal": "POM-2 PC",
             "icon": "Computer.png",
             "subtasks": [
                 {
                     "id": "daily_kim_hex_parent",
-                    "text": "The Hex",
+                    "title": "The Hex",
                     "prereq": "The Hex (Quest)",
                     "icon": "KIM/RetroPfpG.png",
                     "noIconFilter": true,
                     "subtasks": [
                         {
                             "id": "daily_kim_arthur",
-                            "text": "Broadsword (Arthur)",
+                            "title": "Broadsword (Arthur)",
                             "icon": "KIM/RetroPfpA.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_eleanor",
-                            "text": "Salem (Eleanor)",
+                            "title": "Salem (Eleanor)",
                             "icon": "KIM/RetroPfpE.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_lettie",
-                            "text": "Belladona ~{@ (Lettie)",
+                            "title": "Belladona ~{@ (Lettie)",
                             "icon": "KIM/RetroPfpB.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_amir",
-                            "text": "H16h V0l7463 (Amir)",
+                            "title": "H16h V0l7463 (Amir)",
                             "icon": "KIM/RetroPfpC.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_aoi",
-                            "text": "xX GLIMMER Xx (Aoi)",
+                            "title": "xX GLIMMER Xx (Aoi)",
                             "icon": "KIM/RetroPfpD.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_quincy",
-                            "text": "Soldja1Shot1kil (Quincy)",
+                            "title": "Soldja1Shot1kil (Quincy)",
                             "icon": "KIM/RetroPfpF.png",
                             "noIconFilter": true
                         }
@@ -200,28 +211,28 @@
                 },
                 {
                     "id": "daily_kim_roundtable_parent",
-                    "text": "The Roundtable",
+                    "title": "The Roundtable",
                     "prereq": "The Hex (Quest) Finale",
                     "icon": "KIM/RetroPfpM.png",
                     "noIconFilter": true,
                     "subtasks": [
                         {
                             "id": "daily_kim_flare",
-                            "text": "Liminus_Star (Flare)",
+                            "title": "Liminus_Star (Flare)",
                             "icon": "KIM/RetroPfpJ.png",
                             "noIconFilter": true,
                             "prereq": "Rank 4 The Hex"
                         },
                         {
                             "id": "daily_kim_minerva_velimir",
-                            "text": "MomToxicated & PapaPolar (Minerva & Velimir)",
+                            "title": "MomToxicated & PapaPolar (Minerva & Velimir)",
                             "icon": "KIM/RetroPfpI.png",
                             "noIconFilter": true,
                             "prereq": "Rank 5 The Hex"
                         },
                         {
                             "id": "daily_kim_kaya",
-                            "text": "KOLTrial_5115 (Kaya)",
+                            "title": "KOLTrial_5115 (Kaya)",
                             "icon": "KIM/RetroPfpH.png",
                             "noIconFilter": true,
                             "prereq": "Rank 5 The Hex"
@@ -230,26 +241,26 @@
                 },
                 {
                     "id": "daily_kim_devils_triad_parent",
-                    "text": "The Devil's Triad",
+                    "title": "The Devil's Triad",
                     "prereq": "The Old Peace",
                     "icon" : "KIM/Tau_RetroPfpA.png",
                     "noIconFilter": true,
                     "subtasks": [
                         {
                             "id": "daily_kim_marie",
-                            "text": "Marie",
+                            "title": "Marie",
                             "icon": "KIM/Tau_RetroPfpB.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_roathe",
-                            "text": "Roathe",
+                            "title": "Roathe",
                             "icon": "KIM/Tau_RetroPfpD.png",
                             "noIconFilter": true
                         },
                         {
                             "id": "daily_kim_lyon",
-                            "text": "Lyon",
+                            "title": "Lyon",
                             "icon": "KIM/Tau_RetroPfpC.png",
                             "noIconFilter": true,
                             "prereq": "\"Liked\" by Marie"
@@ -260,12 +271,13 @@
         },
         {
             "id": "daily_vendors",
-            "text": "Vendors",
+            "title": "Vendors",
             "icon": "Market.png",
             "subtasks": [
                 {
                     "id": "daily_acrithis",
-                    "text": "Acrithis: Check daily Arcane and Captura offering.",
+                    "title": "Acrithis",
+                    "text": "Check daily Arcane and Captura offering.",
                     "icon": "Acrithis.png",
                     "location": "Duviri/Dormizone",
                     "npc": "Acrithis",
@@ -273,7 +285,8 @@
                 },
                 {
                     "id": "daily_ticker_crew",
-                    "text": "Ticker: Check available railjack crew to hire.",
+                    "title": "Ticker",
+                    "text": "Check available railjack crew to hire.",
                     "icon": "IconCommand.png",
                     "location": "Fortuna, Venus",
                     "npc": "Ticker",
@@ -281,7 +294,8 @@
                 },
                 {
                     "id": "daily_marie",
-                    "text": "Marie: Purchase Tektolyst mods, arcanes, and Perita/Descendia resources.",
+                    "title": "Marie",
+                    "text": "Purchase Tektolyst mods, arcanes, and Perita/Descendia resources.",
                     "icon": "Wisp.png",
                     "location": "La Cathédrale (Sanctum Anatomica, Deimos)",
                     "npc": "Marie",
@@ -293,24 +307,28 @@
     "weekly": [
         {
             "id": "weekly_nightwave_complete",
-            "text": "Nightwave: Complete relevant weekly Nightwave missions.",
+            "title": "Nightwave",
+            "text": "Complete relevant weekly Nightwave missions.",
             "icon": "NightwaveIconSimple.png"
         },
         {
             "id": "weekly_nightwave_spend",
-            "text": "Nightwave (Spend): Spend Nightwave credits if needed (Aura mods, Catalysts/Reactors, etc.).",
+            "title": "Nightwave (Spend)",
+            "text": "Spend Nightwave credits if needed (Aura mods, Catalysts/Reactors, etc.).",
             "icon": "NightwaveIconSimple.png"
         },
         {
             "id": "weekly_ayatan",
-            "text": "Ayatan Treasure Hunt: Complete Maroo's weekly mission for an Ayatan Sculpture",
+            "title": "Ayatan Treasure Hunt",
+            "text": "Complete Maroo's weekly mission for an Ayatan Sculpture",
             "icon": "Maroo.png",
             "location": "Maroo's Bazaar, Mars",
             "npc": "Maroo"
         },
         {
             "id": "weekly_clem",
-            "text": "Help Clem: Help Clem with his weekly survival, or he will die.",
+            "title": "Help Clem",
+            "text": "Help Clem with his weekly survival, or he will die.",
             "icon": "HelpClem_.png",
             "location": "Any Relay",
             "npc": "Darvo",
@@ -318,7 +336,8 @@
         },
         {
             "id": "weekly_kahl_garrison",
-            "text": "Break Narmer: Complete Kahl's weekly mission for Stock.",
+            "title": "Break Narmer",
+            "text": "Complete Kahl's weekly mission for Stock.",
             "icon": "GarrisonIcon.png",
             "location": "Drifter's Camp, Earth",
             "npc": "Kahl",
@@ -326,7 +345,8 @@
         },
         {
             "id": "weekly_archon_hunt",
-            "text": "Archon Hunt: Complete the weekly Archon Hunt for a guaranteed Archon Shard.",
+            "title": "Archon Hunt",
+            "text": "Complete the weekly Archon Hunt for a guaranteed Archon Shard.",
             "icon": "IconNarmer.png",
             "location": "Base of Operations",
             "terminal": "Navigation",
@@ -334,7 +354,8 @@
         },
         {
             "id": "weekly_duviri_circuit",
-            "text": "Duviri Circuit (Normal): Check weekly Warframe options & run Circuit if desired.",
+            "title": "Duviri Circuit (Normal)",
+            "text": "Check weekly Warframe options & run Circuit if desired.",
             "icon": "IconDuviriCategory256.png",
             "location": "Base of Operations/Dormizone",
             "terminal": "Navigation",
@@ -342,7 +363,8 @@
         },
         {
             "id": "weekly_duviri_circuit_sp",
-            "text": "Duviri Circuit (Steel Path): Check weekly Incarnon Adapters & run Circuit if desired.",
+            "title": "Duviri Circuit (Steel Path)",
+            "text": "Check weekly Incarnon Adapters & run Circuit if desired.",
             "icon": "IconDuviriCategory256.png",
             "location": "Base of Operations/Dormizone",
             "terminal": "Navigation",
@@ -350,12 +372,14 @@
         },
         {
             "id": "weekly_search_pulses",
-            "text": "Search Pulses: Use 5 weekly search pulses on Netracells and Archimedeas.",
+            "title": "Search Pulses",
+            "text": "Use 5 weekly search pulses on Netracells and Archimedeas.",
             "icon": "MagnifyingGlassIcon.png",
             "subtasks": [
                 {
                     "id": "weekly_netracells",
-                    "text": "Netracells: Complete up to 5 weekly Netracell missions for Archon Shard chances.",
+                    "title": "Netracells",
+                    "text": "Complete up to 5 weekly Netracell missions for Archon Shard chances.",
                     "icon": "NetraRequiemIcon.png",
                     "location": "Sanctum Anatomica, Deimos",
                     "npc": "Tagfer",
@@ -364,7 +388,8 @@
                 },
                 {
                     "id": "weekly_eda",
-                    "text": "Elite Deep Archimedea: Attempt weekly Elite Deep Archimedea for high Archon Shard chances (very endgame).",
+                    "title": "Elite Deep Archimedea",
+                    "text": "Attempt weekly Elite Deep Archimedea for high Archon Shard chances (very endgame).",
                     "icon": "Necraloid.png",
                     "location": "Sanctum Anatomica, Deimos",
                     "npc": "Necraloid",
@@ -373,7 +398,8 @@
                 },
                 {
                     "id": "weekly_eta",
-                    "text": "Elite Temporal Archimedea: Attempt weekly Elite Temporal Archimedea for high Archon Shard chances (very endgame).",
+                    "title": "Elite Temporal Archimedea",
+                    "text": "Attempt weekly Elite Temporal Archimedea for high Archon Shard chances (very endgame).",
                     "icon": "Kaya_.png",
                     "location": "Höllvania Central Mall",
                     "npc": "Kaya Velasco",
@@ -384,7 +410,8 @@
         },
         {
             "id": "weekly_calendar",
-            "text": "1999 Calendar: Complete weekly Calendar tasks.",
+            "title": "1999 Calendar",
+            "text": "Complete weekly Calendar tasks.",
             "icon": "Computer.png",
             "location": "Base of Operations",
             "terminal": "POM-2 PC",
@@ -392,7 +419,8 @@
         },
         {
             "id": "weekly_invigorations",
-            "text": "Helminth: Use weekly Invigorations.",
+            "title": "Helminth",
+            "text": "Use weekly Invigorations.",
             "icon": "IconHelminth.png",
             "location": "Base of Operations",
             "npc": "Helminth",
@@ -400,21 +428,24 @@
         },
         {
             "id": "weekly_descendia",
-            "text": "The Descendia (Normal): Weekly Tower gamemode for various resources.",
+            "title": "The Descendia (Normal)",
+            "text": "Weekly Tower gamemode for various resources.",
             "icon": "Heat_d.png",
             "location": "Dark Refractory (Base of Operations)",
             "terminal": "Navigation"
         },
         {
             "id": "weekly_descendia_sp",
-            "text": "The Descendia (Steel Path): Weekly Tower gamemode for various resources.",
+            "title": "The Descendia (Steel Path)",
+            "text": "Weekly Tower gamemode for various resources.",
             "icon": "Heat_d.png",
             "location": "Dark Refractory (Base of Operations)",
             "terminal": "Navigation"
         },
         {
             "id": "weekly_clan_initiative",
-            "text": "Clan Weekly Initiatives: Earn rewards by playing with clan members.",
+            "title": "Clan Weekly Initiatives",
+            "text": "Earn rewards by playing with clan members.",
             "icon": "Friends.png",
             "location": "Any Mission*",
             "terminal": "Menu &#x1F782; Communication &#x1F782; Clan",
@@ -422,12 +453,13 @@
         },
         {
             "id": "weekly_vendors",
-            "text": "Vendors",
+            "title": "Vendors",
             "icon": "Market.png",
             "subtasks": [
                 {
                     "id": "weekly_iron_wake",
-                    "text": "Paladino: Trade Riven Slivers.",
+                    "title": "Paladino",
+                    "text": "Trade Riven Slivers.",
                     "icon": "IconOmegaMod256.png",
                     "location": "Iron Wake, Earth",
                     "npc": "Paladino",
@@ -435,7 +467,8 @@
                 },
                 {
                     "id": "weekly_yonta",
-                    "text": "Archimedean Yonta: Buy weekly Kuva with Voidplumes.",
+                    "title": "Archimedean Yonta",
+                    "text": "Buy weekly Kuva with Voidplumes.",
                     "icon": "Yonta.png",
                     "location": "Chrysalith, Zariman",
                     "npc": "Yonta",
@@ -443,7 +476,8 @@
                 },
                 {
                     "id": "weekly_acrithis",
-                    "text": "Acrithis: Check wares and spend Pathos Clamps if desired (Catalysts/Reactors recommended if needed). Buy Kuva with Scuttler Husks.",
+                    "title": "Acrithis",
+                    "text": "Check wares and spend Pathos Clamps if desired (Catalysts/Reactors recommended if needed). Buy Kuva with Scuttler Husks.",
                     "icon": "Acrithis.png",
                     "location": "Duviri/Dormizone",
                     "npc": "Acrithis",
@@ -451,7 +485,8 @@
                 },
                 {
                     "id": "weekly_teshin",
-                    "text": "Teshin (Steel Path): Check Teshin's Steel Essence shop (especially for Umbra Forma rotation every 8 weeks).",
+                    "title": "Teshin (Steel Path)",
+                    "text": "Check Teshin's Steel Essence shop (especially for Umbra Forma rotation every 8 weeks).",
                     "icon": "SteelEssenceIcon.png",
                     "location": "Any Relay",
                     "npc": "Teshin",
@@ -459,7 +494,8 @@
                 },
                 {
                     "id": "weekly_bird3",
-                    "text": "Bird 3: Buy the weekly Archon Shard for 30k Cavia Standing.",
+                    "title": "Bird 3",
+                    "text": "Buy the weekly Archon Shard for 30k Cavia Standing.",
                     "icon": "Bird3.png",
                     "location": "Sanctum Anatomica, Deimos",
                     "npc": "Bird 3",
@@ -467,7 +503,8 @@
                 },
                 {
                     "id": "weekly_kaya",
-                    "text": "Kaya: Trade Pix Chips for Arcanes.",
+                    "title": "Kaya",
+                    "text": "Trade Pix Chips for Arcanes.",
                     "icon": "Kaya_.png",
                     "location": "Höllvania Central Mall",
                     "npc": "Kaya Velasco",
@@ -475,7 +512,8 @@
                 },
                 {
                     "id": "weekly_nightcap",
-                    "text": "Nightcap: Trade Fergolyte for Kuva and Ayatan Sculpture.",
+                    "title": "Nightcap",
+                    "text": "Trade Fergolyte for Kuva and Ayatan Sculpture.",
                     "icon": "MysteryShroom256_d.png",
                     "location": "Fortuna, Venus",
                     "npc": "Nightcap",
@@ -483,7 +521,8 @@
                 },
                 {
                     "id": "weekly_zorba",
-                    "text": "Aspirant Zorba: Trade Atramentum for Kuva.",
+                    "title": "Aspirant Zorba",
+                    "text": "Trade Atramentum for Kuva.",
                     "icon": "ZorbaQuickAccessIcon.png",
                     "location": "Any Relay",
                     "npc": "Aspirant Zorba",
@@ -491,7 +530,8 @@
                 },
                 {
                     "id": "weekly_hunhow",
-                    "text": "Hunhow: Trade Emerald &amp; Crimson Talents for Kuva.",
+                    "title": "Hunhow",
+                    "text": "Trade Emerald &amp; Crimson Talents for Kuva.",
                     "icon": "MarkedForDeathStalker.png",
                     "location": "Pontis Tower, Uranus",
                     "npc": "Hunhow",
@@ -503,7 +543,8 @@
     "other": [
         {
             "id": "other_baro",
-            "text": "Baro Ki'Teer: Check Baro Ki'Teer's inventory and purchase desired items with Ducats (trade Prime parts for Ducats).",
+            "title": "Baro Ki'Teer",
+            "text": "Check Baro Ki'Teer's inventory and purchase desired items with Ducats (trade Prime parts for Ducats).",
             "icon": "IconPrimeParts.png",
             "location": "Relay with Symbol",
             "npc": "Baro Ki'Teer",
@@ -514,7 +555,8 @@
         },
         {
             "id": "other_grandmother_tokens",
-            "text": "Mend the Family: Purchase Family Tokens from Grandmother.",
+            "title": "Mend the Family",
+            "text": "Purchase Family Tokens from Grandmother.",
             "icon": "syndicates/IconEntrati.png",
             "location": "Necralisk, Deimos",
             "prereq": "Heart of Deimos",
@@ -523,7 +565,7 @@
         },
         {
             "id": "other_yonta_voidplumes",
-            "text": "Trade for Voidplumes",
+            "title": "Trade for Voidplumes",
             "icon": "Yonta.png",
             "location": "Chrysalith, Zariman",
             "npc": "Yonta",
@@ -533,7 +575,7 @@
         },
         {
             "id": "other_loid_voca",
-            "text": "Trade for Voca",
+            "title": "Trade for Voca",
             "icon": "MiniMapCaviaVendor_.png",
             "location": "Sanctum Anatomica, Deimos",
             "npc": "Loid",
@@ -543,7 +585,8 @@
         },
         {
             "id": "other_glast",
-            "text": "Tenet Weapons: Check Ergo Glast's shop for good valence bonuses.",
+            "title": "Tenet Weapons",
+            "text": "Check Ergo Glast's shop for good valence bonuses.",
             "icon": "ErgoGlast.png",
             "location": "Any Relay",
             "npc": "Ergo Glast",
@@ -553,7 +596,8 @@
         },
         {
             "id": "other_eleanor",
-            "text": "Coda Weapons: Check Eleanor's shop for good valence bonuses.",
+            "title": "Coda Weapons",
+            "text": "Check Eleanor's shop for good valence bonuses.",
             "icon": "Nyx.png",
             "location": "Höllvania Central Mall",
             "npc": "Eleanor Nightingale",

--- a/sources/tests/app.test.js
+++ b/sources/tests/app.test.js
@@ -54,3 +54,18 @@ describe("displayOtherTaskCountdown({period, duration, ref, observesDst})", () =
         expect(document.querySelector(".other-countdown").textContent).toEqual(countdown);
     })
 });
+
+describe("getTaskById", () => {
+    test.for([
+        ["daily_login", "LotusFlower.png"], // daily
+        ["weekly_kahl_garrison", "GarrisonIcon.png"], // weeklu
+        ["other_grandmother_tokens", "syndicates/IconEntrati.png"], // other
+        ["daily_world_syndicate_hex", "syndicates/HexIcon.png"], // 2nd level daily
+        ["weekly_netracells", "NetraRequiemIcon.png"], // 2nd level weekly
+        ["daily_kim_hex_parent", "KIM/RetroPfpG.png"], // both a parent and child
+        ["daily_kim_kaya", "KIM/RetroPfpH.png"], // 3rd level task
+        ["fake_task_id", undefined]
+    ])("%s", ([id, icon]) => {
+        expect(app.getTaskById(id)?.icon).toEqual(icon);
+    })
+});

--- a/sources/tests/tasks.schema.json
+++ b/sources/tests/tasks.schema.json
@@ -62,6 +62,10 @@
                     "description": "unique identifier for the task",
                     "type": "string"
                 },
+                "title": {
+                    "description": "displayed title of the task",
+                    "type": "string"
+                },
                 "text": {
                     "description": "displayed text of the task",
                     "type": "string"
@@ -123,7 +127,7 @@
                 }
             },
             "additionalProperties": false,
-            "required": ["id", "text"],
+            "required": ["id", "title"],
             "dependentSchemas": {
                 "npc": {
                     "not": {

--- a/sources/tests/version.test.js
+++ b/sources/tests/version.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { APP_VERSION } from "../js/app.js";
+import pkg from "../../package.json" with { type: "json" };
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+describe("check version numbers", () => {
+    test("package.json", () => {
+        expect(pkg.version, "package.json version number does not match app.js APP_VERSION").toEqual(APP_VERSION);
+    });
+
+    test("SECURITY.md", () => {
+        const security = readFileSync(path.resolve(__dirname, "../../SECURITY.md"), "utf-8");
+        const major = security.match(/\| Version \| Supported\s*\|[\r\n]*\| -* \| -* \|[\r\n]*\| (\d+)\.x\.x/)[1];
+        expect(major, "SECURITY.md version number does not match app.js APP_VERSION major version number").toEqual(APP_VERSION.split(".")[0])
+    });
+});


### PR DESCRIPTION
<!-- Do not delete this section -->
**AI Disclosure:**

<!-- Mark *one* box by putting an 'x' between the brackets, like this: [ ] -> [x] -->
- [x] I **did not** use AI for anything in this pull request.
- [ ] I *did* use AI in this pull request, and I have included a statement of AI use in the commit message of *every* commit where I used AI.

<!-- ↓↓↓ Add any other information about your use of AI that you wish to include here ↓↓↓ -->

_____
<!-- ↓↓↓ Write the rest of your pull request below this line ↓↓↓ -->

**This PR builds on #59 and includes all of the changes from that PR <sup>(closes #63)</sup>, plus the following:**

## New Features

* **Task Skipping:** a new "skip"  button next to the hide button on each task lets you hide the task just for the current cycle
  * Skipped tasks are unhidden when the task resets, and when the "Unhide All Tasks" option is activated
  * <details><summary>Screenshot</summary><img width="192" height="175" alt="Screenshot of skip button" src="https://github.com/user-attachments/assets/19aef0d0-b71d-425a-b512-d68b7e011ddb" /></details>
* **List Stats:** task lists (i.e. sections and subtask lists) now have a "list stats" line that tells you how many tasks are not shown due to being hidden, skipped, or completed (when "hide completed tasks" is on)
  * If the "completed", "skipped", or "hidden" count is zero, it is not shown
  * If "hide completed tasks" is off, "completed" is not shown
  * <details><summary>Screenshot</summary><img width="463" height="552" alt="Screenshot of list stats" src="https://github.com/user-attachments/assets/26e5261e-9dd7-4ff0-802b-89f36da028c9" /></details>
* **Hidden Task Lists:** clicking the list stats opens a dialog where you can unhide, unskip, or uncheck individual tasks
  * <details><summary>Screenshots</summary><img width="511" height="252" alt="Screenshot of completed dialog" src="https://github.com/user-attachments/assets/c6bff03c-4d44-460b-a179-9b51e0f54daa" /><img width="493" height="190" alt="Screenshot of skipped dialog" src="https://github.com/user-attachments/assets/dd280641-b9d0-4668-abed-d1f70d489268" /><img width="482" height="221" alt="Screenshot of hidden dialog" src="https://github.com/user-attachments/assets/706a68e2-140f-4a80-8bff-e898a8cfc58d" /></details>
* **Persistent Collapses:** The collapsed/expanded state of parent tasks is now saved.
* **Incomplete Subtask Count:** The number of incomplete subtasks is displayed next to the parent's collapse button when collapsed.
  * <details><summary>Screenshot</summary><img width="447" height="34" alt="Screenshot of incomplete subtasks" src="https://github.com/user-attachments/assets/29160f0a-57b3-4530-98e4-4d77e0741bff" /></details>

## Enhancements

* Hiding a task now uses a collapsing animation (when `prefers-reduced-motion` is off)
* Task titles are displayed as semibold
* Countdown timers use tabular nums (thanks @Nova0255)

## Bug Fixes

* Parent tasks now become checked when all their subtasks are completed *or hidden or skipped* (previously only completed)
* Fixed dialog headers incorrectly having a hover effect
* Fixed intermittent tasks sending a notification when they become unavailable, instead of available

## Code Stuff

* Tasks now define a `title` property, which was formerly the part before the colon in `text`
  * `title` is now a mandatory task property, and `text` is optional
* Duplicate code cleanup:
  * Simplified `createChecklistItem`. A lot of functionality was duplicated between parent and non-parent tasks
  * checkbox onchange is now `checkboxChangeAction` instead of inline
  * Hide and skip buttons are now handled by `hideOrSkipTaskAction`
* The parent task tree walking behavior has been factored out of the checkbox change event and now lives in `updateParentCheckboxes`
  * `updateParentCheckboxes` is now called when you hide/skip or unhide/unskip a task
* Added a new test to check if version numbers match between `app.js`, `package.json`, and `SECURITY.md`.
* Streamlined `loadData`. Properties of `checklistData` are now listed in only ONE place (`newChecklistData`) instead of two or three.
* Added `forEachTask`
* Rewrote `getTaskById` with `forEachTask`
* Renamed `_prepTasks` to `prepTasks`, and rewrote it with `forEachTask`
* Moved assignment of `task.parentId` from `createChecklistItem` to `prepTasks`
* `prepTasks` assigns `task.section`
* v5.3
* U43.0.8 (no changes)

---

This PR is equivalent to [this release](https://github.com/AnSq/Warframe-Task-Checklist/releases/tag/2026-07-28), which is currently live at https://ansq.github.io/Warframe-Task-Checklist/